### PR TITLE
Add a check for ImageMagick

### DIFF
--- a/mosaico.php
+++ b/mosaico.php
@@ -198,3 +198,14 @@ function mosaico_civicrm_pageRun(&$page){
   }
 }
 
+function mosaico_civicrm_check(&$messages) {
+  //Make sure the ImageMagick library is loaded.
+  if( !(extension_loaded('imagick') || class_exists("Imagick"))){
+    $messages[] = new CRM_Utils_Check_Message(
+      'mosaico_imagick',
+      ts('the ImageMagick library is not installed.  The Email Template Builder extension will not work without it.'),
+      ts('ImageMagick not installed'),
+      \Psr\Log\LogLevel::CRITICAL
+    );
+  }
+}


### PR DESCRIPTION
This shows up on the status console on Civi 4.7.  In theory, this hook is supposed to fire on `System.check` on Civi 4.6 and give a notification once a day - but it looks like that code was never written.  Regardless, this works perfectly in 4.7, and maybe one of these days I'll submit a patch to 4.6LTS to fire `hook_check` on `System.check`.