### PR TITLE
2 Quick fixes

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -8,11 +8,11 @@ $(function() {
   // A basic plugin that expose the "viewModel" object as a global variable.
   // plugins = [function(vm) {window.viewModel = vm;}];
   var ok = Mosaico.init({
-    imgProcessorBackend: cmsPath+'/img/',
-    emailProcessorBackend: cmsPath+'/dl/',
+    imgProcessorBackend: cmsPath+'/img',
+    emailProcessorBackend: cmsPath+'/dl',
     titleToken: "MOSAICO Responsive Email Designer",
     fileuploadConfig: {
-      url: cmsPath+'/upload/',
+      url: cmsPath+'/upload',
       // messages??
     }
   }, plugins);

--- a/templates/CRM/Mosaico/Page/Editor.tpl
+++ b/templates/CRM/Mosaico/Page/Editor.tpl
@@ -15,5 +15,8 @@
       setTimeout(addCustomButton, 50);
     }
   }
+  window.print = function() {
+    return false;
+  }
 </script>
 {/literal}


### PR DESCRIPTION
Fix image directories that don't need trailing slash.  #26
Disable window.print() where it isn't needed. #25