### PR TITLE
Fix for space in image name and wordpress image not shown in email

### DIFF
--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -282,7 +282,7 @@ class CRM_Mosaico_Utils {
 
           $static_file_name = $method . "_" . $width . "x" . $height . "_" . $file_name;
 
-          $html = str_ireplace( $matches[ 1 ][ $i ], $config['BASE_URL'] . $config['STATIC_URL'] . urlencode( $static_file_name ), $html );
+          $html = str_ireplace( $matches[ 1 ][ $i ], $config['BASE_URL'] . $config['STATIC_URL'] . rawurlencode( $static_file_name ), $html );//Changed to rawurlencode because space gets into + in the image file name if it has space
 
           $image = self::resizeImage( $file_name, $method, $width, $height );
 

--- a/js/editor.js
+++ b/js/editor.js
@@ -4,11 +4,15 @@ $(function() {
     return;
   }
   var cmsPath = window.location.href.substr(0, window.location.href.lastIndexOf('/'));
+  var imageUrl = cmsPath;
+  if (cmsPath.indexOf('wp-admin/admin.php') !== -1) {//Fix me CRM.url 
+    imageUrl = cmsPath.replace('wp-admin/admin.php','');//In order to stop image urls get admin in there which causes images not being displayed in email for wordpress
+  }
   var plugins;
   // A basic plugin that expose the "viewModel" object as a global variable.
   // plugins = [function(vm) {window.viewModel = vm;}];
   var ok = Mosaico.init({
-    imgProcessorBackend: cmsPath+'/img',
+    imgProcessorBackend: imageUrl+'/img',
     emailProcessorBackend: cmsPath+'/dl',
     titleToken: "MOSAICO Responsive Email Designer",
     fileuploadConfig: {

--- a/packages/mosaico/backend-php/index.php
+++ b/packages/mosaico/backend-php/index.php
@@ -285,7 +285,7 @@ function ProcessDlRequest()
 
 				$static_file_name = $method . "_" . $width . "x" . $height . "_" . $file_name;
 
-				$html = str_ireplace( $matches[ 1 ][ $i ], $config[ BASE_URL ] . $config[ STATIC_URL ] . urlencode( $static_file_name ), $html );
+				$html = str_ireplace( $matches[ 1 ][ $i ], $config[ BASE_URL ] . $config[ STATIC_URL ] . rawurlencode( $static_file_name ), $html );//Changed to rawurlencode because space gets into + in image file name if it has space
 
 				$image = ResizeImage( $file_name, $method, $width, $height );
 


### PR DESCRIPTION
issue - 

1. Image not displayed in email
2. If Image file name has space, then it is converted into +

Above issues are fixed in this PR

