### PR TITLE
bin/setup.sh -- Zip file should always have extension prefix

### DIFF
--- a/bin/add-zip-regex.php
+++ b/bin/add-zip-regex.php
@@ -1,0 +1,31 @@
+#!/usr/bin/php
+<?php
+
+## This script allows you to add to a ZIP file -- while filtering the filename.
+## For example, suppose you want to inject a prefix to put everything in a subdir;
+## match the start of the name (^) and put in the new sub dir:
+##
+## find -type f | add-zip-regex.php myfile.zip :^: 'the-new-sub-dir/'
+
+if (PHP_SAPI !== 'cli') {
+  die("This tool can only be run from command line.");
+}
+
+if (empty($argv[1]) || empty($argv[2])) {
+  die(sprintf("usage: cat files.txt | %s <zipfile> <old-prefix> <new-prefix>\n", $argv[0]));
+}
+
+$zip = new ZipArchive();
+$zip->open($argv[1], ZipArchive::CREATE);
+
+$files = explode("\n", file_get_contents('php://stdin'));
+foreach ($files as $file) {
+  if (empty($file)) {
+    continue;
+  }
+  $file = preg_replace(':^\./:', '', $file);
+  $internalName = preg_replace($argv[2], $argv[3], $file);
+  $zip->addFile($file, $internalName);
+}
+
+$zip->close();

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -3,6 +3,7 @@ set -e
 
 DEFAULT_MOSAICO_BRANCH="v0.15-civicrm-1"
 EXTROOT=$(cd `dirname $0`/..; pwd)
+EXTKEY="uk.co.vedaconsulting.mosaico"
 XMLBUILD="$EXTROOT/build/xml/schema"
 
 ##############################
@@ -111,11 +112,19 @@ function do_zipfile() {
 
   local zipfile="$EXTROOT/build/build.zip"
   [ -f "$zipfile" ] && rm -f "$zipfile"
-  local basedir=$(basename "$EXTROOT")
-  pushd "$EXTROOT/../" >> /dev/null
-    zip "$zipfile" --exclude="*~" "$basedir"/{LICENSE*,README*,info.xml,mosaico*php}
-    zip "$zipfile" --exclude="*~" -r "$basedir"/{CRM,api,bin,css,js,sql,templates,xml}
-    zip "$zipfile" --exclude="*~" -r "$basedir"/packages/mosaico/{NOTICE,README,LICENSE,dist,templates}*
+  pushd "$EXTROOT" >> /dev/null
+    ## Build a list of files to include.
+    ## Put the files into the *.zip, using a $EXTKEY as a prefix.
+    {
+       ## Get any files in the project root.
+       find . -mindepth 1 -maxdepth 1 -type f
+       ## Get any files in the main subfolders.
+       find CRM/ api/ bin/ css/ js/ sql/ templates/ xml/ -type f
+       ## Get the distributable files for Mosaico.
+       find packages/mosaico/{NOTICE,README,LICENSE,dist,templates}* -type f
+    } \
+      | grep -v '~$' \
+      | php bin/add-zip-regex.php "$zipfile" ":^:" "$EXTKEY/"
   popd >> /dev/null
   echo "Created: $zipfile"
 }


### PR DESCRIPTION
Previously, `setup.sh -z` preserved the existing folder name when building
the `*.zip` file. However, in Jenkins, this folder name winds up a bit wonky.

Now, `setup.sh -z` will always use the extension key as the folder prefix.