### PR TITLE
CRM_Mosaico_Page_Editor - Set HTML <base> (#68)

### DIFF
--- a/CRM/Mosaico/Page/Editor.php
+++ b/CRM/Mosaico/Page/Editor.php
@@ -5,6 +5,7 @@ class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
 
   function run() {
     $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assign('baseUrl', CRM_Mosaico_Utils::getMosaicoDistUrl('relative'));
     $smarty->assign('scriptUrls', $this->getScriptUrls());
     $smarty->assign('styleUrls', $this->getStyleUrls());
     $smarty->assign('mosaicoConfig', json_encode(

--- a/templates/CRM/Mosaico/Page/Editor.tpl
+++ b/templates/CRM/Mosaico/Page/Editor.tpl
@@ -4,6 +4,7 @@
 <head>
   <title>CiviCRM Mosaico</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <base href="{$baseUrl|htmlspecialchars}">
 
   {foreach from=$scriptUrls item=scriptUrl}
   <script type="text/javascript" src="{$scriptUrl|htmlspecialchars}">


### PR DESCRIPTION
This is not necessarily right, but it mitigates the issue (#68) which
produces a bunch of inappropriate requests for `civicrm/mosaico/img/<FOO>`.

There are still duplicate requests to lookup template images, but now they
directly hit the filesystem rather than booting CMS+Civi, and they don't
produce warnings about `civicrm/mosaico/img`.