### PR TITLE
crmMosaicoListCtrl - Add screen to CRUD templates

### DIFF
--- a/ang/crmMosaico/Iframe.js
+++ b/ang/crmMosaico/Iframe.js
@@ -1,0 +1,135 @@
+(function(angular, $, _) {
+
+  /**
+   * The class CrmMosaicoIframe allows you to instantiate and manage a
+   * full-screen IFRAME with embedded Mosaico runtime.
+   */
+  angular.module('crmMosaico').factory('CrmMosaicoIframe', function(crmUiAlert, $q, $timeout, $rootScope) {
+
+    /**
+     * @param Object newOptions
+     *  - topMargin: int (optional)
+     *  - url: string (optional)
+     *  - actions: Object
+     *    - save: function(ko, viewModel)
+     *    - test: function(ko, viewModel)
+     *    - close: function(ko, viewModel) (an alias for "save")
+     *  - model: Object. Must have "metadata+content" or "template"
+     *    - metadata: string, JSON-encoded
+     *    - content: string, JSON-encoded
+     *    - template: string, relative file path
+     */
+    return function CrmMosaicoIframe(options){
+      var cfg = {
+        url: CRM.url('civicrm/mosaico/iframe', 'snippet=1'),
+        topMargin: 25 // Height of the CiviCRM navbar. Ugh.
+      };
+      angular.extend(cfg, options);
+
+      var model = cfg.model, actions = cfg.actions;
+      var isVisible = false, $iframe = null, iframe = null;
+
+      if (actions.save && actions.close) {
+        throw "Error: Save and Close actions are mutually exclusive";
+      }
+
+      this.render = function render() {
+        $iframe = $('<iframe frameborder="0" width="100%">');
+        $iframe.css({'z-index': 100, position: 'fixed', left:0, top: cfg.topMargin, width: '100%', height: '100%'});
+        // 'z-index': 100000000
+        iframe = $iframe[0];
+        iframe.setAttribute('src', cfg.url);
+        $('body').append($iframe);
+        return this;
+      };
+
+      // @return Promise<null>
+      this.open = function open() {
+        var dfr = $q.defer();
+
+        if ($iframe) {
+          dfr.resolve();
+          return dfr.promise;
+        }
+
+        window.top.crmMosaicoIframe = function(newWindow, Mosaico, config, plugins) {
+          plugins.push(function(viewModel) {
+            mosaicoPlugin(newWindow.ko, viewModel);
+          });
+
+          var ok = true;
+          if (model.content) {
+            Mosaico.start(config, undefined, JSON.parse(model.metadata), JSON.parse(model.content), plugins);
+          } else if (model.template) {
+            Mosaico.start(config, model.template, undefined, undefined, plugins);
+          } else {
+            crmUiAlert({text: 'Cannot edit mailing'});
+            ok = false;
+          }
+
+          $timeout(function(){
+            if (ok) dfr.resolve();
+            else dfr.reject();
+          }, 150);
+        };
+
+        this.render();
+        return dfr.promise;
+      };
+
+      this.hide = function hide() {
+        isVisible = false;
+        if ($iframe) $iframe.hide();
+        return this;
+      };
+
+      this.show = function show() {
+        isVisible = true;
+        if ($iframe) $iframe.show();
+        return this;
+      };
+
+      this.destroy = function destroy() {
+        this.hide();
+        if ($iframe) $iframe.remove();
+        iframe = $iframe = null;
+        return this;
+      };
+
+      // See https://github.com/voidlabs/mosaico/wiki/Mosaico-Plugins
+      // Generally: Implement the in-dialog "Save" and "Test" buttons.
+      function mosaicoPlugin(ko, viewModel) {
+        // Clicking the default link isn't very useful in IFRAME context.
+        viewModel.logoUrl = null;
+
+        function mkCmd(name, callback) {
+          var cmd = {
+            name: name, // l10n happens in the template
+            enabled: ko.observable(true)
+          };
+          cmd.execute = function() {
+            cmd.enabled(false);
+            $rootScope.$apply(function(){
+              callback(ko, viewModel);
+            });
+            cmd.enabled(true);
+          };
+          return cmd;
+        }
+
+        if (actions.save) {
+          viewModel.save = mkCmd("Save", actions.save);
+        }
+        if (actions.close) { // pretend like Mosaico has a "Close" action.
+          viewModel.save = mkCmd("Close", actions.close);
+        }
+        if (actions.test) {
+          viewModel.test = mkCmd("Test", actions.test);
+        }
+      }
+
+    };
+  });
+
+
+})(angular, CRM.$, CRM._);

--- a/ang/crmMosaico/ListCtrl.html
+++ b/ang/crmMosaico/ListCtrl.html
@@ -11,7 +11,7 @@
     <div class="panel-heading">{{ts('Configured templates')}}</div>
     <div class="panel-body">
       <div class="row">
-        <div ng-repeat="template in crmMosaicoTemplates.getConfigured()">
+        <div ng-repeat="template in crmMosaicoTemplates.getConfigured() | orderBy:'title'">
           <div
               class="col-xs-6 col-md-3 col-lg-3"
               crm-mosaico-template-item="{title: template.title, subtitle: template.type, img: template.thumbnail}"
@@ -28,7 +28,7 @@
     <div class="panel-heading">{{ts('Create new template from...')}}</div>
     <div class="panel-body">
       <div class="row">
-        <div ng-repeat="template in crmMosaicoTemplates.getBases()">
+        <div ng-repeat="template in crmMosaicoTemplates.getBases() | orderBy:'type'">
           <div
               class="col-xs-6 col-md-3 col-lg-3"
               crm-mosaico-template-item="{title: template.type, img: template.thumbnail}"

--- a/ang/crmMosaico/ListCtrl.html
+++ b/ang/crmMosaico/ListCtrl.html
@@ -1,0 +1,43 @@
+<div id="bootstrap-theme" class="crm-mosaico-page">
+
+  <div crm-ui-debug="crmMosaicoTemplates.getBases()"></div>
+  <div crm-ui-debug="crmMosaicoTemplates.getConfigured()"></div>
+
+  <div class="alert alert-info">
+    This page is a <strong>work in progress</strong> that does not manipulate real data.
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">{{ts('Configured templates')}}</div>
+    <div class="panel-body">
+      <div class="row">
+        <div ng-repeat="template in crmMosaicoTemplates.getConfigured()">
+          <div
+              class="col-xs-6 col-md-3 col-lg-3"
+              crm-mosaico-template-item="{title: template.title, subtitle: template.type, img: template.thumbnail}"
+              on-item-click="editTpl(template)"
+              on-item-copy="copyTpl(template)"
+              on-item-delete="deleteTpl(template)"
+          ></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">{{ts('Create new template from...')}}</div>
+    <div class="panel-body">
+      <div class="row">
+        <div ng-repeat="template in crmMosaicoTemplates.getBases()">
+          <div
+              class="col-xs-6 col-md-3 col-lg-3"
+              crm-mosaico-template-item="{title: template.type, img: template.thumbnail}"
+              on-item-click="createTpl(template)"
+          ></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+

--- a/ang/crmMosaico/ListCtrl.html
+++ b/ang/crmMosaico/ListCtrl.html
@@ -3,10 +3,6 @@
   <div crm-ui-debug="crmMosaicoTemplates.getBases()"></div>
   <div crm-ui-debug="crmMosaicoTemplates.getConfigured()"></div>
 
-  <div class="alert alert-info">
-    This page is a <strong>work in progress</strong> that does not manipulate real data.
-  </div>
-
   <div class="panel panel-default">
     <div class="panel-heading">{{ts('Configured templates')}}</div>
     <div class="panel-body">

--- a/ang/crmMosaico/ListCtrl.html
+++ b/ang/crmMosaico/ListCtrl.html
@@ -13,6 +13,7 @@
               crm-mosaico-template-item="{title: template.title, subtitle: template.type, img: template.thumbnail}"
               on-item-click="editTpl(template)"
               on-item-copy="copyTpl(template)"
+              on-item-settings="renameTpl(template)"
               on-item-delete="deleteTpl(template)"
           ></div>
         </div>

--- a/ang/crmMosaico/ListCtrl.js
+++ b/ang/crmMosaico/ListCtrl.js
@@ -56,6 +56,18 @@
         });
     };
 
+    $scope.renameTpl = function renameTpl(tpl) {
+      crmMosaicoPrompt(ts('Template name'), tpl.title)
+        .then(function(newTitle) {
+          return crmStatus(
+            {start: ts('Saving...'), success: ts('Saved')},
+            crmApi('MosaicoTemplate', 'create', {id: tpl.id, title: newTitle}));
+        })
+        .then(function(r){
+          tpl.title = r.values[tpl.id].title;
+        });
+    };
+
     $scope.editTpl = function editTpl(tpl) {
       if (block.check()) {
         return;

--- a/ang/crmMosaico/ListCtrl.js
+++ b/ang/crmMosaico/ListCtrl.js
@@ -13,7 +13,7 @@
     }
   );
 
-  angular.module('crmMosaico').controller('CrmMosaicoListCtrl', function($scope, crmApi, crmStatus, crmUiHelp, crmMosaicoTemplates, CrmMosaicoIframe, crmBlocker) {
+  angular.module('crmMosaico').controller('CrmMosaicoListCtrl', function($scope, crmApi, crmStatus, crmUiHelp, crmMosaicoTemplates, CrmMosaicoIframe, crmBlocker, crmMosaicoPrompt) {
     // The ts() and hs() functions help load strings for this module.
     var ts = $scope.ts = CRM.ts('mosaico');
     var hs = $scope.hs = crmUiHelp({file: 'CRM/crmMosaico/ListCtrl'}); // See: templates/CRM/crmMosaico/ListCtrl.hlp
@@ -31,27 +31,29 @@
     });
 
     $scope.createTpl = function createTpl(tpl) {
-      return crmStatus(
-        {start: ts('Creating...'), success: ts('Created')},
-        crmMosaicoTemplates.create({
-          base: tpl.baseDetails.name,
-          title: ts('%1 (New Template)', {1: tpl.type})
+      return crmMosaicoPrompt(ts('Template name'), ts('New Template (%1)', {1: tpl.type}))
+        .then(function(newTitle) {
+          return crmStatus(
+            {start: ts('Creating...'), success: ts('Created')},
+            crmMosaicoTemplates.create({base: tpl.baseDetails.name, title: newTitle})
+          );
         })
-      ).then(function(newTpl){
-        return $scope.editTpl(newTpl);
-      });
+        .then(function(newTpl) {
+          return $scope.editTpl(newTpl);
+        });
     };
 
     $scope.copyTpl = function copyTpl(tpl) {
-      return crmStatus(
-        {start: ts('Copying...'), success: ts('Copied')},
-        crmMosaicoTemplates.clone({
-          id: tpl.id,
-          title: ts('%1 (Copy)', {1: tpl.title})
+      return crmMosaicoPrompt(ts('Template name'), ts('Copy of %1', {1: tpl.title}))
+        .then(function(newTitle) {
+          return crmStatus(
+            {start: ts('Copying...'), success: ts('Copied')},
+            crmMosaicoTemplates.clone({id: tpl.id, title: newTitle})
+          );
         })
-      ).then(function(newTpl){
-        return $scope.editTpl(newTpl);
-      });
+        .then(function(newTpl) {
+          return $scope.editTpl(newTpl);
+        });
     };
 
     $scope.editTpl = function editTpl(tpl) {
@@ -67,7 +69,7 @@
       warmTplId = tpl.id;
       var openPromise = crmMosaicoTemplates.getFull(tpl).then(function(fullTpl) {
         if (crmMosaicoIframe) crmMosaicoIframe.destroy();
-        
+
         crmMosaicoIframe = new CrmMosaicoIframe({
           model: {
             template: tpl.baseDetails.path,

--- a/ang/crmMosaico/ListCtrl.js
+++ b/ang/crmMosaico/ListCtrl.js
@@ -20,32 +20,38 @@
 
     $scope.crmMosaicoTemplates = crmMosaicoTemplates;
 
-    $scope.createTpl = function(template) {
+    $scope.createTpl = function(tpl) {
       return crmStatus(
         {start: ts('Creating...'), success: ts('Created')},
-        crmMosaicoTemplates.copy(template, {title: 'New template'})
-      ).then(function(newTemplate){
-        return $scope.editTpl(newTemplate);
+        crmMosaicoTemplates.create({
+          base: tpl.baseDetails.name,
+          title: ts('%1 (New Template)', {1: tpl.type})
+        })
+      ).then(function(newTpl){
+        return $scope.editTpl(newTpl);
       });
     };
 
-    $scope.copyTpl = function(template) {
+    $scope.copyTpl = function(tpl) {
       return crmStatus(
         {start: ts('Copying...'), success: ts('Copied')},
-        crmMosaicoTemplates.copy(template, {title: ts('Copy of %1', {1: template.title})})
-      ).then(function(newTemplate){
-        return $scope.editTpl(newTemplate);
+        crmMosaicoTemplates.clone({
+          id: tpl.id,
+          title: ts('%1 (Copy)', {1: tpl.title})
+        })
+      ).then(function(newTpl){
+        return $scope.editTpl(newTpl);
       });
     };
 
-    $scope.editTpl = function(template) {
-      CRM.alert('Edit: ' + template.title); // FIXME
+    $scope.editTpl = function(tpl) {
+      CRM.alert('Edit: ' + tpl.title); // FIXME
     };
 
-    $scope.deleteTpl = function(template) {
+    $scope.deleteTpl = function(tpl) {
       return crmStatus(
         {start: ts('Deleting...'), success: ts('Deleted')},
-        crmMosaicoTemplates.delete(template)
+        crmMosaicoTemplates.delete(tpl)
       );
     };
 

--- a/ang/crmMosaico/ListCtrl.js
+++ b/ang/crmMosaico/ListCtrl.js
@@ -1,0 +1,54 @@
+(function(angular, $, _) {
+
+  angular.module('crmMosaico').config(function($routeProvider) {
+      $routeProvider.when('/mosaico-template', {
+        controller: 'CrmMosaicoListCtrl',
+        templateUrl: '~/crmMosaico/ListCtrl.html',
+        resolve: {
+          tpls: function(crmMosaicoTemplates){
+            return crmMosaicoTemplates.whenLoaded();
+          }
+        }
+      });
+    }
+  );
+
+  angular.module('crmMosaico').controller('CrmMosaicoListCtrl', function($scope, crmApi, crmStatus, crmUiHelp, crmMosaicoTemplates) {
+    // The ts() and hs() functions help load strings for this module.
+    var ts = $scope.ts = CRM.ts('mosaico');
+    var hs = $scope.hs = crmUiHelp({file: 'CRM/crmMosaico/ListCtrl'}); // See: templates/CRM/crmMosaico/ListCtrl.hlp
+
+    $scope.crmMosaicoTemplates = crmMosaicoTemplates;
+
+    $scope.createTpl = function(template) {
+      return crmStatus(
+        {start: ts('Creating...'), success: ts('Created')},
+        crmMosaicoTemplates.copy(template, {title: 'New template'})
+      ).then(function(newTemplate){
+        return $scope.editTpl(newTemplate);
+      });
+    };
+
+    $scope.copyTpl = function(template) {
+      return crmStatus(
+        {start: ts('Copying...'), success: ts('Copied')},
+        crmMosaicoTemplates.copy(template, {title: ts('Copy of %1', {1: template.title})})
+      ).then(function(newTemplate){
+        return $scope.editTpl(newTemplate);
+      });
+    };
+
+    $scope.editTpl = function(template) {
+      CRM.alert('Edit: ' + template.title); // FIXME
+    };
+
+    $scope.deleteTpl = function(template) {
+      return crmStatus(
+        {start: ts('Deleting...'), success: ts('Deleted')},
+        crmMosaicoTemplates.delete(template)
+      );
+    };
+
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ang/crmMosaico/ListCtrl.js
+++ b/ang/crmMosaico/ListCtrl.js
@@ -31,7 +31,7 @@
     });
 
     $scope.createTpl = function createTpl(tpl) {
-      return crmMosaicoPrompt(ts('Template name'), ts('New Template (%1)', {1: tpl.type}))
+      return crmMosaicoPrompt(ts('Create new template'), ts('New Template (%1)', {1: tpl.type}))
         .then(function(newTitle) {
           return crmStatus(
             {start: ts('Creating...'), success: ts('Created')},
@@ -44,7 +44,7 @@
     };
 
     $scope.copyTpl = function copyTpl(tpl) {
-      return crmMosaicoPrompt(ts('Template name'), ts('Copy of %1', {1: tpl.title}))
+      return crmMosaicoPrompt(ts('Create new template'), ts('Copy of %1', {1: tpl.title}))
         .then(function(newTitle) {
           return crmStatus(
             {start: ts('Copying...'), success: ts('Copied')},
@@ -57,7 +57,7 @@
     };
 
     $scope.renameTpl = function renameTpl(tpl) {
-      crmMosaicoPrompt(ts('Template name'), tpl.title)
+      crmMosaicoPrompt(ts('Edit template name'), tpl.title)
         .then(function(newTitle) {
           return crmStatus(
             {start: ts('Saving...'), success: ts('Saved')},

--- a/ang/crmMosaico/ListCtrl.js
+++ b/ang/crmMosaico/ListCtrl.js
@@ -13,14 +13,24 @@
     }
   );
 
-  angular.module('crmMosaico').controller('CrmMosaicoListCtrl', function($scope, crmApi, crmStatus, crmUiHelp, crmMosaicoTemplates) {
+  angular.module('crmMosaico').controller('CrmMosaicoListCtrl', function($scope, crmApi, crmStatus, crmUiHelp, crmMosaicoTemplates, CrmMosaicoIframe, crmBlocker) {
     // The ts() and hs() functions help load strings for this module.
     var ts = $scope.ts = CRM.ts('mosaico');
     var hs = $scope.hs = crmUiHelp({file: 'CRM/crmMosaico/ListCtrl'}); // See: templates/CRM/crmMosaico/ListCtrl.hlp
-
+    var block = $scope.block = crmBlocker();
     $scope.crmMosaicoTemplates = crmMosaicoTemplates;
 
-    $scope.createTpl = function(tpl) {
+    // Track zero or one instances of CrmMosaicoIframe.
+    var crmMosaicoIframe, warmTplId;
+    $scope.$on("$destroy", function() {
+      if (crmMosaicoIframe) {
+        crmMosaicoIframe.destroy();
+        crmMosaicoIframe = null;
+        warmTplId = null;
+      }
+    });
+
+    $scope.createTpl = function createTpl(tpl) {
       return crmStatus(
         {start: ts('Creating...'), success: ts('Created')},
         crmMosaicoTemplates.create({
@@ -32,7 +42,7 @@
       });
     };
 
-    $scope.copyTpl = function(tpl) {
+    $scope.copyTpl = function copyTpl(tpl) {
       return crmStatus(
         {start: ts('Copying...'), success: ts('Copied')},
         crmMosaicoTemplates.clone({
@@ -44,8 +54,47 @@
       });
     };
 
-    $scope.editTpl = function(tpl) {
-      CRM.alert('Edit: ' + tpl.title); // FIXME
+    $scope.editTpl = function editTpl(tpl) {
+      if (block.check()) {
+        return;
+      }
+
+      if (warmTplId == tpl.id) {
+        crmMosaicoIframe.show();
+        return;
+      }
+
+      warmTplId = tpl.id;
+      var openPromise = crmMosaicoTemplates.getFull(tpl).then(function(fullTpl) {
+        if (crmMosaicoIframe) crmMosaicoIframe.destroy();
+        
+        crmMosaicoIframe = new CrmMosaicoIframe({
+          model: {
+            template: tpl.baseDetails.path,
+            metadata: fullTpl.metadata,
+            content: fullTpl.content
+          },
+          actions: {
+            save: function(ko, viewModel) {
+              viewModel.metadata.changed = Date.now();
+
+              var savePromise = crmApi('MosaicoTemplate', 'create', {
+                id: tpl.id,
+                html: viewModel.exportHTML(),
+                metadata: viewModel.exportMetadata(),
+                content: viewModel.exportJSON()
+              }).then(function() {
+                crmMosaicoIframe.hide();
+              });
+
+              crmStatus({start: ts('Saving'), success: ts('Saved')}, savePromise);
+            }
+          }
+        });
+        return crmMosaicoIframe.open();
+      });
+
+      block(crmStatus({start: ts('Loading...'), success: null}, openPromise));
     };
 
     $scope.deleteTpl = function(tpl) {

--- a/ang/crmMosaico/MixinCtrl.js
+++ b/ang/crmMosaico/MixinCtrl.js
@@ -12,6 +12,7 @@
     // Hrm, would like `ng-controller="CrmMosaicoMixinCtrl as mosaicoCtrl`, but that's not working...
     $scope.mosaicoCtrl = {
       templates: [],
+      // Fill a given "mailing" which the chosen "template".
       select: function(mailing, template) {
         var topt = mailing.template_options = mailing.template_options || {};
         var promise = crmMosaicoTemplates.getFull(template).then(function(tplCtnt){
@@ -24,6 +25,7 @@
         });
         return crmStatus({start: ts('Loading...'), success: null}, promise);
       },
+      // Figure out which "template" was previously used with a "mailing."
       getTemplate: function(mailing) {
         if (!mailing || !mailing.template_options || !mailing.template_options.mosaicoTemplate) {
           return null;
@@ -33,6 +35,7 @@
         });
         return matches.length > 0 ? matches[0] : null;
       },
+      // Reset all Mosaico data in a "mailing'.
       reset: function(mailing) {
         if (crmMosaicoIframe) crmMosaicoIframe.destroy();
         crmMosaicoIframe = null;
@@ -41,6 +44,7 @@
         delete mailing.template_options.mosaicoContent;
         mailing.body_html = '';
       },
+      // Edit a mailing in Mosaico.
       edit: function(mailing) {
         if (crmMosaicoIframe) {
           crmMosaicoIframe.show();
@@ -86,6 +90,7 @@
       }
     };
 
+    // Open a dialog of advanced options.
     $scope.openAdvancedOptions = function() {
       var model = {mailing: $scope.mailing, attachments: $scope.attachments};
       var options = CRM.utils.adjustDialogDefaults(angular.extend(

--- a/ang/crmMosaico/MixinCtrl.js
+++ b/ang/crmMosaico/MixinCtrl.js
@@ -2,10 +2,12 @@
 
   // This provides additional actions for editing a Mosaico mailing.
   // It coexists with crmMailing's EditMailingCtrl.
-  angular.module('crmCxn').controller('CrmMosaicoMixinCtrl', function CrmMosaicoMixinCtrl($scope, dialogService, crmMosaicoTemplates, crmStatus) {
+  angular.module('crmCxn').controller('CrmMosaicoMixinCtrl', function CrmMosaicoMixinCtrl($scope, dialogService, crmMosaicoTemplates, crmStatus, CrmMosaicoIframe, $timeout) {
     // var ts = $scope.ts = CRM.ts(null);
 
     // Main data is in $scope.mailing, $scope.mosaicoCtrl.template
+
+    var crmMosaicoIframe = null;
 
     // Hrm, would like `ng-controller="CrmMosaicoMixinCtrl as mosaicoCtrl`, but that's not working...
     $scope.mosaicoCtrl = {
@@ -32,49 +34,55 @@
         return matches.length > 0 ? matches[0] : null;
       },
       reset: function(mailing) {
+        if (crmMosaicoIframe) crmMosaicoIframe.destroy();
+        crmMosaicoIframe = null;
         delete mailing.template_options.mosaicoTemplate;
         delete mailing.template_options.mosaicoMetadata;
         delete mailing.template_options.mosaicoContent;
         mailing.body_html = '';
       },
-      // Open a dialog running Mosaico in an iframe.
       edit: function(mailing) {
-        var model = {url: CRM.url('civicrm/mosaico/iframe', 'snippet=1')};
-        var options = CRM.utils.adjustDialogDefaults(angular.extend(
-          {
-            autoOpen: false,
-            height: '96%',
-            width: '96%',
-            title: ts('Edit Design')
+        if (crmMosaicoIframe) {
+          crmMosaicoIframe.show();
+          return;
+        }
+
+        function syncModel(viewModel) {
+          mailing.body_html = viewModel.exportHTML();
+          mailing.template_options = mailing.template_options || {};
+          // Mosaico exports JSON. Keep their original encoding... or else the loader throws an error.
+          mailing.template_options.mosaicoMetadata = viewModel.exportMetadata();
+          mailing.template_options.mosaicoContent = viewModel.exportJSON();
+        }
+
+        crmMosaicoIframe = new CrmMosaicoIframe({
+          model: {
+            template: $scope.mosaicoCtrl.getTemplate(mailing).path,
+            metadata: mailing.template_options.mosaicoMetadata,
+            content: mailing.template_options.mosaicoContent
           },
-          options
-        ));
-        window.top.crmMosaicoIframe = function(newWindow, Mosaico, config, plugins) {
-          plugins.push(function(viewModel) {
-            mosaicoPlugin(newWindow.ko, viewModel);
-          });
+          actions: {
+            close: function(ko, viewModel) {
+              viewModel.metadata.changed = Date.now();
+              syncModel(viewModel);
+              // TODO: When autosave is better integrated, remove this.
+              $timeout(function(){$scope.save();}, 100);
+              crmMosaicoIframe.hide('crmMosaicoEditorDialog');
+            },
+            test: function(ko, viewModel) {
+              syncModel(viewModel);
 
-          if (mailing.template_options && mailing.template_options.mosaicoMetadata) {
-            Mosaico.start(config, undefined,
-              JSON.parse(mailing.template_options.mosaicoMetadata),
-              JSON.parse(mailing.template_options.mosaicoContent),
-              plugins);
-            return;
+              var model = {mailing: $scope.mailing, attachments: $scope.attachments};
+              var options = CRM.utils.adjustDialogDefaults(angular.extend(
+                {autoOpen: false, title: ts('Test Mailing')},
+                options
+              ));
+              return dialogService.open('crmMosaicoPreviewDialog', '~/crmMosaico/PreviewDialogCtrl.html', model, options);
+            }
           }
+        });
 
-          var template = $scope.mosaicoCtrl.getTemplate(mailing);
-          if (template) {
-            Mosaico.start(config, template.path, undefined, undefined, plugins);
-            return;
-          }
-
-          CRM.alert('Cannot edit mailing');
-        };
-        return dialogService.open('crmMosaicoEditorDialog', '~/crmMosaico/EditorDialogCtrl.html', model, options)
-          .then(function(item) {
-            // mailing.msg_template_id = item.id;
-            return item;
-          });
+        return crmStatus({start: ts('Loading...'), success: null}, crmMosaicoIframe.open());
       }
     };
 
@@ -94,55 +102,12 @@
       $scope.mosaicoCtrl.templates = crmMosaicoTemplates.getAll();
     });
 
-    // See https://github.com/voidlabs/mosaico/wiki/Mosaico-Plugins
-    // Generally: Implement the in-dialog "Save" and "Test" buttons.
-    function mosaicoPlugin(ko, viewModel) {
-      viewModel.logoUrl = null;
-
-      function syncModel() {
-        $scope.mailing.body_html = viewModel.exportHTML();
-        $scope.mailing.template_options = $scope.mailing.template_options || {};
-        // Mosaico exports JSON. Keep their original encoding... or else the loader throws an error.
-        $scope.mailing.template_options.mosaicoMetadata = viewModel.exportMetadata();
-        $scope.mailing.template_options.mosaicoContent = viewModel.exportJSON();
+    $scope.$on("$destroy", function() {
+      if (crmMosaicoIframe) {
+        crmMosaicoIframe.destroy();
+        crmMosaicoIframe = null;
       }
-
-      var saveCmd = {
-        name: 'Save', // l10n happens in the template
-        enabled: ko.observable(true)
-      };
-      saveCmd.execute = function() {
-        saveCmd.enabled(false);
-        viewModel.metadata.changed = Date.now();
-        syncModel();
-        saveCmd.enabled(true);
-        dialogService.close('crmMosaicoEditorDialog');
-        $scope.save();
-      };
-      viewModel.save = saveCmd;
-
-      var testCmd = {
-        name: 'Test', // l10n happens in the template
-        enabled: ko.observable(true)
-      };
-      testCmd.execute = function() {
-        // testCmd.enabled(false);
-        // CRM.alert('TODO: Test');
-        // testCmd.enabled(true);
-        syncModel();
-
-        var model = {mailing: $scope.mailing, attachments: $scope.attachments};
-        var options = CRM.utils.adjustDialogDefaults(angular.extend(
-          {
-            autoOpen: false,
-            title: ts('Test Mailing')
-          },
-          options
-        ));
-        return dialogService.open('crmMosaicoPreviewDialog', '~/crmMosaico/PreviewDialogCtrl.html', model, options);
-      };
-      viewModel.test = testCmd;
-    }
+    });
 
   });
 

--- a/ang/crmMosaico/Prompt.js
+++ b/ang/crmMosaico/Prompt.js
@@ -1,0 +1,15 @@
+(function(angular, $, _) {
+  angular.module('crmMosaico').factory('crmMosaicoPrompt', function($q) {
+    // Display a quick question/prompt.
+    // @return Promise<string>
+    return function crmMosaicoPrompt(question, defaultName) {
+      var dfr = $q.defer();
+      var answer = window.prompt(question, defaultName);
+
+      if (!_.isEmpty(answer)) dfr.resolve(answer);
+      else dfr.reject();
+
+      return dfr.promise;
+    };
+  });
+})(angular, CRM.$, CRM._);

--- a/ang/crmMosaico/TemplateItem.html
+++ b/ang/crmMosaico/TemplateItem.html
@@ -1,6 +1,8 @@
 <span class="thumbnail crm-mosaico-template-item">
   <img alt="{{myOptions.title}}" src="{{myOptions.img}}" style="height: 180px; width: 100%; display: block;" ng-click="fireAction('onItemClick')">
-    <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-search" ng-if="hasAction('onItemPreview')" ng-click="fireAction('onItemPreview')"></a>
+    <a style="float: right;" class="btn btn-xs btn-danger-outline glyphicon glyphicon-remove-sign" title="Delete" ng-if="hasAction('onItemDelete')" crm-confirm="{type: 'delete', obj: {title: 'template'}}" on-yes="fireAction('onItemDelete')"></a>
+    <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-duplicate" title="Copy" ng-if="hasAction('onItemCopy')" ng-click="fireAction('onItemCopy')"></a>
+    <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-search" title="Preview" ng-if="hasAction('onItemPreview')" ng-click="fireAction('onItemPreview')"></a>
     <a ng-click="fireAction('onItemClick')">
       {{myOptions.title}}
       <small ng-if="myOptions.subtitle"><br/>{{myOptions.subtitle}}</small>

--- a/ang/crmMosaico/TemplateItem.html
+++ b/ang/crmMosaico/TemplateItem.html
@@ -2,6 +2,7 @@
   <img alt="{{myOptions.title}}" src="{{myOptions.img}}" style="height: 180px; width: 100%; display: block;" ng-click="fireAction('onItemClick')">
     <a style="float: right;" class="btn btn-xs btn-danger-outline glyphicon glyphicon-remove-sign" title="Delete" ng-if="hasAction('onItemDelete')" crm-confirm="{type: 'delete', obj: {title: 'template'}}" on-yes="fireAction('onItemDelete')"></a>
     <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-duplicate" title="Copy" ng-if="hasAction('onItemCopy')" ng-click="fireAction('onItemCopy')"></a>
+    <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-wrench" title="Settings" ng-if="hasAction('onItemSettings')" ng-click="fireAction('onItemSettings')"></a>
     <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-search" title="Preview" ng-if="hasAction('onItemPreview')" ng-click="fireAction('onItemPreview')"></a>
     <a ng-click="fireAction('onItemClick')">
       {{myOptions.title}}

--- a/ang/crmMosaico/Templates.js
+++ b/ang/crmMosaico/Templates.js
@@ -7,6 +7,7 @@
     function filterBase(base) {
       return {
         id: 'base-' + base.name,
+        baseDetails: base,
         title: ts('Empty Template'),
         type: base.title,
         thumbnail: base.thumbnail,
@@ -18,6 +19,7 @@
       var base = cache.basesByName[tpl.base];
       return {
         id: tpl.id,
+        baseDetails: base,
         title: tpl.title,
         type: base.title,
         thumbnail: base.thumbnail,
@@ -36,6 +38,13 @@
       cache.all = _.union(cache.bases, cache.configured);
     });
 
+    function arrayDel(array, item) {
+      var p = _.indexOf(array, item);
+      if (p >= 0) {
+        array.splice(item, 1);
+      }
+    }
+
     return {
       // Return Promise<void>
       whenLoaded: function whenLoaded() {
@@ -45,6 +54,25 @@
             else $timeout(poll, 100);
           };
           poll();
+        });
+      },
+      // @return Promise<Template>
+      copy: function(template, params) {
+        return $q(function(r){
+          var newTemplate = angular.extend({}, template, params);
+          newTemplate.id = Math.round(Math.random() *10000);
+          cache.configured.push(newTemplate);
+          cache.all.push(newTemplate);
+          $timeout(function(){r(newTemplate);}, 500);
+        });
+      },
+      // @return Promise<null>
+      'delete': function(template) {
+        CRM.alert('Delete: ' + template.title); // FIXME
+        return $q(function(r){
+          arrayDel(cache.configured, template);
+          arrayDel(cache.all, template);
+          $timeout(function(){r();}, 500);
         });
       },
       // Load the full content of a template (HTML, metadata, content -- as applicable).

--- a/api/v3/MosaicoTemplate.php
+++ b/api/v3/MosaicoTemplate.php
@@ -44,3 +44,44 @@ function civicrm_api3_mosaico_template_delete($params) {
 function civicrm_api3_mosaico_template_get($params) {
   return _civicrm_api3_basic_get('CRM_Mosaico_BAO_MosaicoTemplate', $params);
 }
+
+/**
+ * Adjust metadata for clone spec action.
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_mosaico_template_clone_spec(&$spec) {
+  $mailingFields = CRM_Mosaico_DAO_MosaicoTemplate::fields();
+  $spec['id'] = $mailingFields['id'];
+  $spec['id']['api.required'] = 1;
+}
+
+/**
+ * Clone mailing.
+ *
+ * @param array $params
+ *
+ * @return array
+ * @throws \CiviCRM_API3_Exception
+ */
+function civicrm_api3_mosaico_template_clone($params) {
+  $BLACKLIST = array('id');
+
+  $newParams = CRM_Utils_Array::subset($params, array(
+    'debug',
+    'title',
+    'base',
+    'html',
+    'metadata',
+    'content',
+  ));
+
+  $get = civicrm_api3('MosaicoTemplate', 'getsingle', array('id' => $params['id']));
+  foreach ($get as $field => $value) {
+    if (!isset($newParams[$field]) && !in_array($field, $BLACKLIST)) {
+      $newParams[$field] = $value;
+    }
+  }
+
+  return civicrm_api3('MosaicoTemplate', 'create', $newParams);
+}

--- a/mosaico.civix.php
+++ b/mosaico.civix.php
@@ -56,6 +56,20 @@ function _mosaico_civix_civicrm_install() {
 }
 
 /**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ */
+function _mosaico_civix_civicrm_postInstall() {
+  _mosaico_civix_civicrm_config();
+  if ($upgrader = _mosaico_civix_upgrader()) {
+    if (is_callable(array($upgrader, 'onPostInstall'))) {
+      $upgrader->onPostInstall();
+    }
+  }
+}
+
+/**
  * Implements hook_civicrm_uninstall().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
@@ -212,14 +226,14 @@ function _mosaico_civix_civicrm_caseTypes(&$caseTypes) {
 }
 
 /**
-* (Delegated) Implements hook_civicrm_angularModules().
-*
-* Find any and return any files matching "ang/*.ang.php"
-*
-* Note: This hook only runs in CiviCRM 4.5+.
-*
-* @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-*/
+ * (Delegated) Implements hook_civicrm_angularModules().
+ *
+ * Find any and return any files matching "ang/*.ang.php"
+ *
+ * Note: This hook only runs in CiviCRM 4.5+.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+ */
 function _mosaico_civix_civicrm_angularModules(&$angularModules) {
   if (!is_dir(__DIR__ . '/ang')) {
     return;
@@ -259,24 +273,17 @@ function _mosaico_civix_glob($pattern) {
  * @param array $menu - menu hierarchy
  * @param string $path - path where insertion should happen (ie. Administer/System Settings)
  * @param array $item - menu you need to insert (parent/child attributes will be filled for you)
- * @param int $parentId - used internally to recurse in the menu structure
  */
-function _mosaico_civix_insert_navigation_menu(&$menu, $path, $item, $parentId = NULL) {
-  static $navId;
-
+function _mosaico_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    if (!$navId) $navId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_navigation");
-    $navId ++;
-    $menu[$navId] = array (
-      'attributes' => array_merge($item, array(
+    $menu[] = array(
+      'attributes' => array_merge(array(
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-        'parentID'   => $parentId,
-        'navID'      => $navId,
-      ))
+      ), $item),
     );
-    return true;
+    return TRUE;
   }
   else {
     // Find an recurse into the next level down
@@ -290,6 +297,49 @@ function _mosaico_civix_insert_navigation_menu(&$menu, $path, $item, $parentId =
       }
     }
     return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _mosaico_civix_navigationMenu(&$nodes) {
+  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+    _mosaico_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _mosaico_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+    });
+  _mosaico_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _mosaico_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _mosaico_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
   }
 }
 

--- a/mosaico.php
+++ b/mosaico.php
@@ -171,6 +171,16 @@ function mosaico_civicrm_navigationMenu(&$params){
     ),
   );
 
+  _mosaico_civix_insert_navigation_menu($params, 'Mailings', array(
+    'label' => ts('Mosaico Templates', array('domain' => 'org.civicrm.styleguide')),
+    'name' => 'mosaico_templates',
+    'permission' => 'access CiviCRM Mosaico',
+    'child' => array(),
+    'operator' => 'OR',
+    'separator' => 0,
+    'url' => CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mosaico-template'),
+  ));
+
   _mosaico_civix_navigationMenu($menu);
 }
 

--- a/mosaico.php
+++ b/mosaico.php
@@ -35,6 +35,15 @@ function mosaico_civicrm_install() {
 }
 
 /**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ */
+function mosaico_civicrm_postInstall() {
+  _mosaico_civix_civicrm_postInstall();
+}
+
+/**
  * Implements hook_civicrm_uninstall().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
@@ -161,6 +170,8 @@ function mosaico_civicrm_navigationMenu(&$params){
       'permission'=> 'access CiviCRM Mosaico',
     ),
   );
+
+  _mosaico_civix_navigationMenu($menu);
 }
 
 

--- a/templates/CRM/crmMosaico/ListCtrl.hlp
+++ b/templates/CRM/crmMosaico/ListCtrl.hlp
@@ -1,0 +1,3 @@
+{htxt id="full_name"}
+{ts}The contact name  should be divided in two parts, the first name and last name.{/ts}
+{/htxt}

--- a/tests/phpunit/CRM/Mosaico/MosaicoTemplateTest.php
+++ b/tests/phpunit/CRM/Mosaico/MosaicoTemplateTest.php
@@ -61,4 +61,27 @@ class CRM_Mosaico_MosaicoTemplateTest extends CRM_Mosaico_TestCase implements En
     ));
   }
 
+  public function testClone() {
+    $createResult = $this->callAPISuccess('MosaicoTemplate', 'create', array(
+      'title' => 'MosaicoTemplateTest foo',
+      'base' => 'versafix-1',
+      'html' => '<p>hello</p>',
+      'metadata' => json_encode(array('foo' => 'bar')),
+      'content' => json_encode(array('abc' => 'def')),
+    ));
+
+    $cloneResult = $this->callAPISuccess('MosaicoTemplate', 'clone', array(
+      'id' => $createResult['id'],
+      'title' => 'MosaicoTemplateTest bar',
+    ));
+    $clone = $cloneResult['values'][$cloneResult['id']];
+
+    $this->assertNotEquals($clone['id'], $createResult['id']);
+    $this->assertEquals('MosaicoTemplateTest bar', $clone['title']);
+    $this->assertEquals('versafix-1', $clone['base']);
+    $this->assertEquals('<p>hello</p>', $clone['html']);
+    $this->assertEquals(json_encode(array('foo' => 'bar')), $clone['metadata']);
+    $this->assertEquals(json_encode(array('abc' => 'def')), $clone['content']);
+  }
+
 }


### PR DESCRIPTION
Changes
 * The main feature here is the addition of a screen, "Mailings => Mosaico Templates" where you can browse/edit/delete templates using a thumbnail grid.
 * As a smaller point, some of the logic for opening Mosaico's IFRAME has been moved from `crmMosaicoMixinCtrl` to a new service, `CrmMosaicoIframe`.
 * The IFRAME is behaviorally modal, but we had pushback on displaying it as a modal. It's configured to take more of the screen.
 * Some aspects of opening/closing the IFRAME have been improved -- e.g. (1) the "Loading" message should be more accurate, and (2) the IFRAME can be reused when you reopen the same Mosaico content, which should reduce wait time.
