### PR TITLE
Deliver mailings via FlexMailer

### DIFF
--- a/CRM/Mosaico/MosaicoComposer.php
+++ b/CRM/Mosaico/MosaicoComposer.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Class CRM_Mosaico_MosaicoComposer
+ *
+ * Responsible for composing individual emails based on the email content.
+ *
+ * For the most part, we use the same structure as CiviMail -- with some
+ * exceptions (like disabling Smarty).
+ */
+class CRM_Mosaico_MosaicoComposer extends \Civi\FlexMailer\Listener\DefaultComposer {
+
+  public function isSupported(\CRM_Mailing_DAO_Mailing $mailing) {
+    return $mailing->template_type === 'mosaico';
+  }
+
+  public function createTokenProcessorContext(
+    \Civi\FlexMailer\Event\ComposeBatchEvent $e
+  ) {
+    $context = parent::createTokenProcessorContext($e);
+    // Smarty would break Mosaico CSS.
+    $context['smarty'] = FALSE;
+    return $context;
+  }
+
+  public function createMailParams(
+    \Civi\FlexMailer\Event\ComposeBatchEvent $e,
+    \Civi\FlexMailer\FlexMailerTask $task,
+    \Civi\Token\TokenRow $row
+  ) {
+    $mailParams = parent::createMailParams($e, $task, $row);
+    $mailParams['X-CiviMail-Mosaico'] = 'Yes';
+    return $mailParams;
+  }
+
+  public function createMessageTemplates($mailing) {
+    $templates = parent::createMessageTemplates($mailing);
+    // unset($templates['text']);
+    return $templates;
+  }
+
+}

--- a/CRM/Mosaico/MosaicoComposer.php
+++ b/CRM/Mosaico/MosaicoComposer.php
@@ -34,8 +34,10 @@ class CRM_Mosaico_MosaicoComposer extends \Civi\FlexMailer\Listener\DefaultCompo
   }
 
   public function createMessageTemplates($mailing) {
+    // Currently building on the BAO's behavior for reconciling
+    // HTML/text and header/body/footer.
     $templates = parent::createMessageTemplates($mailing);
-    // unset($templates['text']);
+    \_mosaico_civicrm_alterMailContent($templates);
     return $templates;
   }
 

--- a/CRM/Mosaico/Services.php
+++ b/CRM/Mosaico/Services.php
@@ -21,7 +21,7 @@ class CRM_Mosaico_Services {
       return;
     }
     $container->setDefinition('mosaico_flexmail_composer', new Definition('CRM_Mosaico_MosaicoComposer'));
-    // $container->setDefinition('mosaico_flexmail_url_filter', new Definition('CRM_Mosaico_UrlFilter'));
+    $container->setDefinition('mosaico_flexmail_url_filter', new Definition('CRM_Mosaico_UrlFilter'));
 
     foreach (self::getListenerSpecs() as $listenerSpec) {
       $container->findDefinition('dispatcher')->addMethodCall('addListenerService', $listenerSpec);
@@ -32,7 +32,7 @@ class CRM_Mosaico_Services {
     $listenerSpecs = array();
 
     $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_composer', 'onCompose'), FM::WEIGHT_MAIN);
-    // $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_url_filter', 'onCompose'), FM::WEIGHT_ALTER - 100);
+    $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_url_filter', 'onCompose'), FM::WEIGHT_ALTER - 100);
 
     return $listenerSpecs;
   }

--- a/CRM/Mosaico/Services.php
+++ b/CRM/Mosaico/Services.php
@@ -20,7 +20,7 @@ class CRM_Mosaico_Services {
     if (!CRM_Extension_System::singleton()->getMapper()->isActiveModule('flexmailer')) {
       return;
     }
-    // $container->setDefinition('mosaico_flexmail_composer', new Definition('CRM_Mosaico_MosaicoComposer'));
+    $container->setDefinition('mosaico_flexmail_composer', new Definition('CRM_Mosaico_MosaicoComposer'));
     // $container->setDefinition('mosaico_flexmail_url_filter', new Definition('CRM_Mosaico_UrlFilter'));
 
     foreach (self::getListenerSpecs() as $listenerSpec) {
@@ -31,7 +31,7 @@ class CRM_Mosaico_Services {
   protected static function getListenerSpecs() {
     $listenerSpecs = array();
 
-    // $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_composer', 'onCompose'), FM::WEIGHT_MAIN);
+    $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_composer', 'onCompose'), FM::WEIGHT_MAIN);
     // $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_url_filter', 'onCompose'), FM::WEIGHT_ALTER - 100);
 
     return $listenerSpecs;

--- a/CRM/Mosaico/Services.php
+++ b/CRM/Mosaico/Services.php
@@ -1,0 +1,40 @@
+<?php
+
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Civi\FlexMailer\FlexMailer as FM;
+
+/**
+ * Class CRM_Mosaico_Services
+ *
+ * Define the services
+ */
+class CRM_Mosaico_Services {
+
+  public static function registerServices(ContainerBuilder $container) {
+    if (version_compare(\CRM_Utils_System::version(), '4.7.0', '>=')) {
+      $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
+    }
+
+    if (!CRM_Extension_System::singleton()->getMapper()->isActiveModule('flexmailer')) {
+      return;
+    }
+    // $container->setDefinition('mosaico_flexmail_composer', new Definition('CRM_Mosaico_MosaicoComposer'));
+    // $container->setDefinition('mosaico_flexmail_url_filter', new Definition('CRM_Mosaico_UrlFilter'));
+
+    foreach (self::getListenerSpecs() as $listenerSpec) {
+      $container->findDefinition('dispatcher')->addMethodCall('addListenerService', $listenerSpec);
+    }
+  }
+
+  protected static function getListenerSpecs() {
+    $listenerSpecs = array();
+
+    // $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_composer', 'onCompose'), FM::WEIGHT_MAIN);
+    // $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_url_filter', 'onCompose'), FM::WEIGHT_ALTER - 100);
+
+    return $listenerSpecs;
+  }
+
+}

--- a/CRM/Mosaico/UrlFilter.php
+++ b/CRM/Mosaico/UrlFilter.php
@@ -1,0 +1,70 @@
+<?php
+
+use Civi\FlexMailer\Event\ComposeBatchEvent;
+use Civi\FlexMailer\Listener\SimpleFilter;
+
+/**
+ * Class ImageUrlFilter
+ * @package Civi\FlexMailer\Listener
+ *
+ * Find relative URLs and convert to absolute URLs.
+ */
+class CRM_Mosaico_UrlFilter extends \Civi\FlexMailer\Listener\BaseListener {
+
+  /**
+   * @var string|NULL
+   */
+  protected $baseUrl = NULL;
+
+  public function onCompose(ComposeBatchEvent $e) {
+    if (!$this->isActive() || $e->getMailing()->template_type !== 'mosaico') {
+      return;
+    }
+
+    SimpleFilter::byColumn($e, 'html', array($this, 'filterHtml'));
+  }
+
+  /**
+   * Find any image URLs and ensure they're absolute (not relative).
+   *
+   * @param array<string> $htmls
+   * @return array<string>
+   *   Filtered HTML, with relative IMG url's changed to absolute URLs.
+   */
+  public function filterHtml($htmls) {
+    $callback = function ($matches) {
+      if (preg_match('/^https?:/', $matches[2])) {
+        return $matches[0];
+      }
+
+      return $matches[1] . $this->getBaseUrl() . $matches[2] . $matches[3];
+    };
+
+    $htmls = preg_replace_callback(';(\<img [^>]*src *= *")([^">]+)(");i', $callback, $htmls);
+    $htmls = preg_replace_callback(';(\<img [^>]*src *= *\')([^">]+)(\');i', $callback, $htmls);
+    $htmls = preg_replace_callback(';(\<table [^>]*background *= *")([^">]+)(");i', $callback, $htmls);
+    $htmls = preg_replace_callback(';(\<table [^>]*background *= *")([^\'>]+)(\');i', $callback, $htmls);
+    // WISHLIST: CSS backgrounds?
+    return $htmls;
+  }
+
+  /**
+   * @return string|NULL
+   */
+  public function getBaseUrl() {
+    if ($this->baseUrl === NULL) {
+      $this->baseUrl = \CRM_Utils_File::addTrailingSlash(CIVICRM_UF_BASEURL, '/');
+    }
+    return $this->baseUrl;
+  }
+
+  /**
+   * @param string|NULL $baseUrl
+   * @return CRM_Mosaico_UrlFilter
+   */
+  public function setBaseUrl($baseUrl) {
+    $this->baseUrl = $baseUrl;
+    return $this;
+  }
+
+}

--- a/CRM/Mosaico/UrlFilter.php
+++ b/CRM/Mosaico/UrlFilter.php
@@ -38,7 +38,7 @@ class CRM_Mosaico_UrlFilter extends \Civi\FlexMailer\Listener\BaseListener {
     $domainBase = $this->createDomainBase($stdBase);
 
     $callback = function ($matches) use ($stdBase, $domainBase) {
-      if (preg_match('/^https?:/', $matches[2])) {
+      if (preg_match('/^https?:/', $matches[2]) || empty($matches[2])) {
         return $matches[0];
       }
 

--- a/info.xml
+++ b/info.xml
@@ -24,6 +24,7 @@
   <requires>
     <!-- FIXME: This is too tightly coupled, e.g. precludes org.civicrm.bootstrapcivihr -->
     <ext>org.civicrm.bootstrapcivicrm</ext>
+    <ext>org.civicrm.flexmailer</ext>
   </requires>
   <comments>To help contribute please contact us on support@vedaconsulting.co.uk or initiate a conversation / issue on github.</comments>
   <civix>

--- a/mosaico.php
+++ b/mosaico.php
@@ -336,3 +336,14 @@ function mosaico_civicrm_pre($op, $objectName, $id, &$params) {
     }
   }
 }
+
+/**
+ * Implements hook_civicrm_container().
+ */
+function mosaico_civicrm_container(\Symfony\Component\DependencyInjection\ContainerBuilder $container) {
+  if (version_compare(\CRM_Utils_System::version(), '4.7.0', '>=')) {
+    $container->addResource(new \Symfony\Component\Config\Resource\FileResource(__FILE__));
+  }
+  require_once 'CRM/Mosaico/Services.php';
+  CRM_Mosaico_Services::registerServices($container);
+}

--- a/mosaico.php
+++ b/mosaico.php
@@ -261,6 +261,14 @@ function mosaico_civicrm_check(&$messages) {
       \Psr\Log\LogLevel::CRITICAL
     );
   }
+  if (!CRM_Extension_System::singleton()->getMapper()->isActiveModule('flexmailer')) {
+    $messages[] = new CRM_Utils_Check_Message(
+      'mosaico_flexmailer',
+      ts('Mosaico uses FlexMailer for delivery. Please install the extension "org.civicrm.flexmailer".'),
+      ts('FlexMailer required'),
+      \Psr\Log\LogLevel::CRITICAL
+    );
+  }
 }
 
 /**

--- a/mosaico.php
+++ b/mosaico.php
@@ -274,9 +274,15 @@ function mosaico_civicrm_permission(&$permissions) {
 }
 
 /**
- * Implements hook_civicrm_alterMailContent().
+ * Convert dyanmic-y image URLs to static-y URLs.
+ *
+ * This is analogous to alterMailContent, but we only apply to Mosaico mailings.
+ *
+ * @param $content
+ *   This parameter seems a bit confused.
+ * @see CRM_Mosaico_MosaicoComposer
  */
-function mosaico_civicrm_alterMailContent(&$content) {
+function _mosaico_civicrm_alterMailContent(&$content) {
   /**
    * create absolute urls for Mosaico/imagemagick images when sending an email in CiviMail
    * convert string below into just the absolute url with addition of static directory where correctly sized image is stored

--- a/tests/phpunit/CRM/Mosaico/UrlFilterTest.php
+++ b/tests/phpunit/CRM/Mosaico/UrlFilterTest.php
@@ -71,6 +71,11 @@ class CRM_Mosaico_UrlFilterTest extends CRM_Mosaico_TestCase implements EndToEnd
       '<p>Hello <img src="/foo.png"> world.</p>',
       '<p>Hello <img src="http://abc.example.com/foo.png"> world.</p>',
     );
+    $cases[] = array(
+      'http://abc.example.com/def/',
+      '<p>Hello <img src=""> world.</p>',
+      '<p>Hello <img src=""> world.</p>',
+    );
     return $cases;
   }
 

--- a/tests/phpunit/CRM/Mosaico/UrlFilterTest.php
+++ b/tests/phpunit/CRM/Mosaico/UrlFilterTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Civi\Test\EndToEndInterface;
+
+require_once __DIR__ . '/TestCase.php';
+
+/**
+ * Class CRM_Mosaico_UrlFilterTest
+ *
+ * Unit tests for filtering of URLs within HTML.
+ *
+ * @group e2e
+ */
+class CRM_Mosaico_UrlFilterTest extends CRM_Mosaico_TestCase implements EndToEndInterface {
+
+  public function filterExamples() {
+    $cases = array();
+
+    $cases[] = array(
+      'http://abc.example.com/def/',
+      '<p>Hello <img src="http://other.example.com/foo.png"> world.</p>',
+      '<p>Hello <img src="http://other.example.com/foo.png"> world.</p>',
+    );
+    $cases[] = array(
+      'http://abc.example.com/def/',
+      '<p>Hello <img noise="1" src="foo.png"> world.</p>',
+      '<p>Hello <img noise="1" src="http://abc.example.com/def/foo.png"> world.</p>',
+    );
+    $cases[] = array(
+      'http://abc.example.com/def/',
+      "<p>Hello <img noise=\"1\"\n src=\"foo.png\"> world.</p>",
+      "<p>Hello <img noise=\"1\"\n src=\"http://abc.example.com/def/foo.png\"> world.</p>",
+    );
+    $cases[] = array(
+      'http://abc.example.com/def/',
+      '<p>Hello <IMG noise="1" SRC="foo.png"> world.</p>',
+      '<p>Hello <IMG noise="1" SRC="http://abc.example.com/def/foo.png"> world.</p>',
+    );
+    $cases[] = array(
+      'http://abc.example.com/ghi/',
+      '<img src=\'bar.png\' noise="2"><p>Hello <img noise="1" src="foo.png"> world.</p>',
+      '<img src=\'http://abc.example.com/ghi/bar.png\' noise="2"><p>Hello <img noise="1" src="http://abc.example.com/ghi/foo.png"> world.</p>',
+    );
+    $cases[] = array(
+      'http://abc.example.com/def/',
+      '<p>Hello <img noise="1" src="foo.png"/> world.</p>',
+      '<p>Hello <img noise="1" src="http://abc.example.com/def/foo.png"/> world.</p>',
+    );
+    $cases[] = array(
+      'http://abc.example.com/def/',
+      '<garbage><p>Hello <img noise="1" src="foo.png"> world.</p>',
+      '<garbage><p>Hello <img noise="1" src="http://abc.example.com/def/foo.png"> world.</p>',
+    );
+    $cases[] = array(
+      'http://abc.example.com/def/',
+      '<p>Hello <img noise="1" src="foo.png"> world.</p></garbage>',
+      '<p>Hello <img noise="1" src="http://abc.example.com/def/foo.png"> world.</p></garbage>',
+    );
+    $cases[] = array(
+      'http://abc.example.com/def/',
+      '<p>Hello <garbage src="foo.png"> world.</p></garbage>',
+      '<p>Hello <garbage src="foo.png"> world.</p></garbage>',
+    );
+    $cases[] = array(
+      'http://abc.example.com/def/',
+      '<table border="0" background="example.gif"><tbody>...',
+      '<table border="0" background="http://abc.example.com/def/example.gif"><tbody>...',
+    );
+    return $cases;
+  }
+
+  /**
+   * @param string $inputHtml
+   * @param string $expectHtml
+   * @dataProvider filterExamples
+   */
+  public function testFilter($baseUrl, $inputHtml, $expectHtml) {
+    $filter = new CRM_Mosaico_UrlFilter();
+    $filter->setBaseUrl($baseUrl);
+    list($actual) = $filter->filterHtml(array($inputHtml));
+    $this->assertEquals($expectHtml, $actual);
+  }
+
+}

--- a/tests/phpunit/CRM/Mosaico/UrlFilterTest.php
+++ b/tests/phpunit/CRM/Mosaico/UrlFilterTest.php
@@ -66,6 +66,11 @@ class CRM_Mosaico_UrlFilterTest extends CRM_Mosaico_TestCase implements EndToEnd
       '<table border="0" background="example.gif"><tbody>...',
       '<table border="0" background="http://abc.example.com/def/example.gif"><tbody>...',
     );
+    $cases[] = array(
+      'http://abc.example.com/def/',
+      '<p>Hello <img src="/foo.png"> world.</p>',
+      '<p>Hello <img src="http://abc.example.com/foo.png"> world.</p>',
+    );
     return $cases;
   }
 


### PR DESCRIPTION
FlexMailer (https://github.com/civicrm/org.civicrm.flexmailer/) is a refactored version of CiviMail's backend that provides more opportunities to interject/override/explore the steps of the email delivery process.

This patch specifically allows to:
 * Completely opt-out of Smarty
 * Convert relative URLs to absolute URLs
 * Only activate our modifications when handling Mosaico messages