### PR TITLE
sql/auto_uninstall.sql - Cleanup after uninstall

### DIFF
--- a/sql/auto_uninstall.sql
+++ b/sql/auto_uninstall.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS `civicrm_mosaico_msg_template`;
+DROP TABLE IF EXISTS `civicrm_mosaico_template`;


### PR DESCRIPTION
If you try to uninstall and reinstall the extension, it fails to pre-existing tables.

In theory, the distinction between `disable` and `uninstall` is that
`uninstall` is supposed to wipe out data and leave you with a clean slate.