### PR TITLE
bin/setup.sh - Zip file should include placeholders for directories

### DIFF
--- a/bin/add-zip-regex.php
+++ b/bin/add-zip-regex.php
@@ -17,6 +17,7 @@ if (empty($argv[1]) || empty($argv[2])) {
 
 $zip = new ZipArchive();
 $zip->open($argv[1], ZipArchive::CREATE);
+$zip->addEmptyDir($argv[3]);
 
 $files = explode("\n", file_get_contents('php://stdin'));
 foreach ($files as $file) {
@@ -25,7 +26,12 @@ foreach ($files as $file) {
   }
   $file = preg_replace(':^\./:', '', $file);
   $internalName = preg_replace($argv[2], $argv[3], $file);
-  $zip->addFile($file, $internalName);
+  if (file_exists($file) && is_dir($file)) {
+    $zip->addEmptyDir($internalName);
+  }
+  else {
+    $zip->addFile($file, $internalName);
+  }
 }
 
 $zip->close();

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -117,11 +117,11 @@ function do_zipfile() {
     ## Put the files into the *.zip, using a $EXTKEY as a prefix.
     {
        ## Get any files in the project root.
-       find . -mindepth 1 -maxdepth 1 -type f
+       find . -mindepth 1 -maxdepth 1 -type f -o -type d
        ## Get any files in the main subfolders.
-       find CRM/ ang/ api/ bin/ css/ js/ sql/ templates/ xml/ -type f
+       find CRM/ ang/ api/ bin/ css/ js/ sql/ templates/ xml/ -type f -o -type d
        ## Get the distributable files for Mosaico.
-       find packages/mosaico/{NOTICE,README,LICENSE,dist,templates}* -type f
+       find packages/mosaico/{NOTICE,README,LICENSE,dist,templates}* -type f -o -type d
     } \
       | grep -v '~$' \
       | php bin/add-zip-regex.php "$zipfile" ":^:" "$EXTKEY/"


### PR DESCRIPTION
The significance of this depends on the decompressor.  Unix `unzip` doesn't
need these, but PHP `ZipArchive` does.  Consequently, if you actually used
the zip files with the in-app downloader, they failed.  This fixes them.