### PR TITLE
info.xml, mosaico.php - Rename `bootstrapcivicrm` to `shoreditch`

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -23,7 +23,7 @@
   </compatibility>
   <requires>
     <!-- FIXME: This is too tightly coupled, e.g. precludes org.civicrm.bootstrapcivihr -->
-    <ext>org.civicrm.bootstrapcivicrm</ext>
+    <ext>org.civicrm.shoreditch</ext>
     <ext>org.civicrm.flexmailer</ext>
   </requires>
   <comments>To help contribute please contact us on support@vedaconsulting.co.uk or initiate a conversation / issue on github.</comments>

--- a/mosaico.php
+++ b/mosaico.php
@@ -253,10 +253,10 @@ function mosaico_civicrm_check(&$messages) {
       \Psr\Log\LogLevel::CRITICAL
     );
   }
-  if (!CRM_Extension_System::singleton()->getMapper()->isActiveModule('bootstrapcivicrm')) {
+  if (!CRM_Extension_System::singleton()->getMapper()->isActiveModule('shoreditch') && !CRM_Extension_System::singleton()->getMapper()->isActiveModule('bootstrapcivicrm')) {
     $messages[] = new CRM_Utils_Check_Message(
       'mosaico_bootstrap',
-      ts('Mosaico uses Bootstrap CSS. Please install the extension "org.civicrm.bootstrapcivicrm".'),
+      ts('Mosaico uses Bootstrap CSS. Please install the extension "org.civicrm.shoreditch".'),
       ts('Bootstrap required'),
       \Psr\Log\LogLevel::CRITICAL
     );


### PR DESCRIPTION
The Bootstrap-based theme has been moved from CiviHR to a standalone
extension.  This makes it easier to install (e.g.  `cv dl --dev
shoreditch`).

See also: https://civicrm.org/extensions/shoreditch