### PR TITLE
Refine handling required fields

### DIFF
--- a/ang/crmMosaico/BlockMailing.html
+++ b/ang/crmMosaico/BlockMailing.html
@@ -1,7 +1,7 @@
 <div ng-form="subform" crm-ui-id-scope>
 
   <div class="form-group">
-    <label for="inputTitle" class="control-label">{{ts('Mailing Name')}}
+    <label for="inputTitle" class="control-label required">{{ts('Mailing Name')}}
       <a crm-ui-help="hs({id: 'name', title: ts('Mailing Name')})"></a></label>
     <input type="text" class="form-control" id="inputTitle" placeholder="{{ts('Mailing Name')}}" ng-model="mailing.name">
   </div>
@@ -19,7 +19,7 @@
   </div>
 
   <div class="form-group">
-    <label for="inputFrom" class="control-label">{{ts('From')}}
+    <label for="inputFrom" class="control-label required">{{ts('From')}}
       <a crm-ui-help="hs({id: 'from_email', title: ts('From')})"></a></label>
     <div ng-controller="EmailAddrCtrl" crm-mailing-from-address="fromPlaceholder" crm-mailing="mailing">
       <select
@@ -53,12 +53,12 @@
   </div>
 
   <div class="form-group">
-    <label for="inputRecipients" class="control-label">{{ts('Recipients')}}</label>
+    <label for="inputRecipients" class="control-label required">{{ts('Recipients')}}</label>
     <div crm-mailing-block-recipients="{name: 'recipients', id: 'subform.recipients'}" crm-mailing="mailing"></div>
   </div>
 
   <div class="form-group">
-    <label for="inputSubject" class="control-label">{{ts('Subject')}}</label>
+    <label for="inputSubject" class="control-label required">{{ts('Subject')}}</label>
     <!--<div style="float: right;">-->
       <!--<input crm-mailing-token on-select="$broadcast('insert:subject', token.name)" tabindex="-1"/>-->
     <!--</div>-->
@@ -76,7 +76,7 @@
 
   <span ng-controller="EditUnsubGroupCtrl">
               <div class="form-group" ng-if="isUnsubGroupRequired(mailing)">
-                <label for="inputUnsubscribeGroup" class="control-label">{{ts('Unsubscribe Group')}}</label>
+                <label for="inputUnsubscribeGroup" class="control-label required">{{ts('Unsubscribe Group')}}</label>
                 <select
                     class="form-control"
                     id="inputUnsubscribeGroup"
@@ -91,7 +91,7 @@
             </span>
 
   <div class="form-group" ng-if="crmMailingConst.isMultiLingual">
-    <label for="inputLanguage">{{ts('Language')}}</label>
+    <label for="inputLanguage" class="control-label required">{{ts('Language')}}</label>
     <select
         id="inputLanguage"
         name="language"

--- a/ang/crmMosaico/EditMailingCtrl/mosaico.html
+++ b/ang/crmMosaico/EditMailingCtrl/mosaico.html
@@ -19,11 +19,12 @@
                 {{ts('Reset')}}
               </button>
             </div>
-            <span>{{ts('Design')}}</span>
+            <span class="required">{{ts('Design')}}</span>
             <div style="clear: both"></div>
           </div>
           <div class="panel-body">
             <div class="row">
+              <span ng-model="body_html_defined" crm-ui-validate="!!mailing.body_html"></span>
               <div
                   class="col-xs-6 col-md-3 crm-mosaico-selected"
                   crm-mosaico-template-item="{title: ts('My Design'), subtitle: mosaicoCtrl.getTemplate(mailing).type, img: mosaicoCtrl.getTemplate(mailing).thumbnail}"


### PR DESCRIPTION
This PR makes two changes:
 * Visually, various required fields are now *displayed* with the typical red "*".
 * Functionally, the "Design" block is now treated as required. (You cannot send a mailing without providing some content.)