### PR TITLE
Navigation Menu - Only show one template management link

### DIFF
--- a/mosaico.php
+++ b/mosaico.php
@@ -129,23 +129,23 @@ function mosaico_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 }
 
 function mosaico_civicrm_navigationMenu(&$params) {
-  $parentId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Mailings', 'id', 'name');
+  //$parentId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Mailings', 'id', 'name');
   //$msgTpls  = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Message Templates', 'id', 'name');
 
-  $maxId       = max(array_keys($params));
-  $msgTplMaxId = empty($msgTpls) ? $maxId + 10 : $msgTpls;
-  $params[$parentId]['child'][$msgTplMaxId] = array(
-    'attributes' => array(
-      'label'     => ts('Message Template Builder'),
-      'name'      => 'Message_Template_Builder',
-      'url'       => CRM_Utils_System::url('civicrm/mosaico/index', 'reset=1', TRUE),
-      'active'    => 1,
-      'parentID'  => $parentId,
-      'operator'  => NULL,
-      'navID'     => $msgTplMaxId,
-      'permission' => 'access CiviCRM Mosaico',
-    ),
-  );
+  //  $maxId       = max(array_keys($params));
+  //  $msgTplMaxId = empty($msgTpls) ? $maxId + 10 : $msgTpls;
+  //  $params[$parentId]['child'][$msgTplMaxId] = array(
+  //    'attributes' => array(
+  //      'label'     => ts('Message Template Builder'),
+  //      'name'      => 'Message_Template_Builder',
+  //      'url'       => CRM_Utils_System::url('civicrm/mosaico/index', 'reset=1', TRUE),
+  //      'active'    => 1,
+  //      'parentID'  => $parentId,
+  //      'operator'  => NULL,
+  //      'navID'     => $msgTplMaxId,
+  //      'permission' => 'access CiviCRM Mosaico',
+  //    ),
+  //  );
 
   _mosaico_civix_insert_navigation_menu($params, 'Mailings', array(
     'label' => ts('Mosaico Templates', array('domain' => 'org.civicrm.styleguide')),


### PR DESCRIPTION
At the moment, we store the message templates and mailing templates
separately.  This is not ideal -- the two should be reconciled.
However, in the mean time, listing both at the top-level gets
the user to start-off in a rough place. ("What's the difference
between 'Message Template' and 'Mosaico Template'?")

Ideally, perhaps we would update the `civicrm/a/#/mosaico-template` UI to
allow CRUDing message-templates and deal with msgtpl properties (like
"Subject" and "Text"). That's a bigger project.

This patch is not ideal, but it at least defers the cognitive dissonance.
With this patch, there are two navigation paths to creating Mosaico-based
templates:

 1. When you first install Mosaico, the expectation is to manage
    templates for mail-blasts. You want to get to `civicrm/a/#/mosaico-template`,
    so this is the item in the main-menu.
 2. If you want to send transactional emails using Mosaico-based templates,
    then you're already pretty educated about Civi and have probably seen
    "Administer => Communications => Message Templates"
    (`civicrm/admin/messageTemplates`) before.  Go back to that screen and
    choose the "Mosaico" tab.