### PR TITLE
(Consider) Enforce more permissions

### DIFF
--- a/mosaico.php
+++ b/mosaico.php
@@ -150,9 +150,9 @@ function mosaico_civicrm_navigationMenu(&$params) {
   _mosaico_civix_insert_navigation_menu($params, 'Mailings', array(
     'label' => ts('Mosaico Templates', array('domain' => 'org.civicrm.styleguide')),
     'name' => 'mosaico_templates',
-    'permission' => 'access CiviCRM Mosaico',
+    'permission' => 'access CiviCRM Mosaico,edit message templates',
     'child' => array(),
-    'operator' => 'OR',
+    'operator' => 'AND',
     'separator' => 0,
     'url' => CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mosaico-template'),
   ));

--- a/mosaico.php
+++ b/mosaico.php
@@ -116,6 +116,9 @@ function mosaico_civicrm_caseTypes(&$caseTypes) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
  */
 function mosaico_civicrm_angularModules(&$angularModules) {
+  if (!CRM_Core_Permission::check('access CiviCRM Mosaico')) {
+    return;
+  }
   _mosaico_civix_civicrm_angularModules($angularModules);
 }
 
@@ -335,6 +338,9 @@ function _mosaico_civicrm_alterMailContent(&$content) {
  * @throws \CRM_Core_Exception
  */
 function mosaico_civicrm_mailingTemplateTypes(&$types) {
+  if (!CRM_Core_Permission::check('access CiviCRM Mosaico')) {
+    return;
+  }
   $messages = array();
   mosaico_civicrm_check($messages);
   $editorUrl = empty($messages)

--- a/mosaico.php
+++ b/mosaico.php
@@ -160,6 +160,26 @@ function mosaico_civicrm_navigationMenu(&$params) {
   _mosaico_civix_navigationMenu($params);
 }
 
+/**
+ * Implements hook_civicrm_alterAPIPermissions().
+ *
+ * @link https://docs.civicrm.org/dev/en/master/hooks/hook_civicrm_alterAPIPermissions/
+ */
+function mosaico_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
+  $permissions['mosaico_base_template']['get'] = array(
+    array('access CiviCRM Mosaico'),
+  );
+
+  $permissions['mosaico_template']['get'] = array(
+    array('access CiviCRM Mosaico'),
+  );
+  $permissions['mosaico_template']['create'] = array(
+    'access CiviCRM Mosaico', // and...
+    'edit message templates',
+  );
+  $permissions['mosaico_template']['update'] = $permissions['mosaico_template']['create'];
+}
+
 function mosaico_civicrm_pageRun(&$page) {
   $pageName = $page->getVar('_name');
   if ($pageName == 'Civi\Angular\Page\Main') {


### PR DESCRIPTION
During testing, one of the testers provided this feedback:

> User with following permissions can view/edit/clone/delete Mosaico Templates
>
>   "CiviCRM: edit message templates" and "CiviMail Mosaico: access CiviCRM Mosaico"
>
> OR
>
>    "CiviCRM: administer CiviCRM"
>
> But when removing the "edit message templates" (and keep "access CiviCRM
> Mosaico") they can still access Mosaico Templates page
> (/civicrm/a/#/mosaico-template)

(1) My initial feeling was to go along with this.  This PR is based on realizing that view. To be explicit, the interpretation here seems to be:

 * To create/edit a *template* using Mosaico, user A needs `access CiviCRM Mosaico` and `edit message templates`.
 * Once the template is created, user B needs `access CiviCRM Mosaico` to use the template.

The PR almost handles it - but we'll need another core patch to make it complete. (Specifically, the mailing "Selector" shows all mailings regardless of type. However, if you don't have permission to create/edit Mosaico templates, then you shouldn't see options to continue/reuse Mosaico-based mailings. I guess we'd want to filter the selector automatically based on what template-types are visible to the user.)

(2) However, on second thought, I think maybe there's been a miscommunication about what the permission was supposed to mean.  In the earlier alpha/beta, the permissions probably meant:

 * To create/edit a *template* using Mosaico, user A needs `access CiviCRM Mosaico`.
 * Once the template is created, user B doesn't need any special Mosaico permissions. (Ex: As long as you have access to CiviMail, then you can use a Mosaico based template without any special permissions.)

In this case, let's close this PR. Instead, I could submit another which renames the permission to `edit Mosaico message templates`.

(3) But personally, I'm not certain that any new permission actually makes sense.  Bear with me for a second: `civicrm-core` already defines separate permissions for `edit message templates` and `access CiviMail`. When you activate the extension, you'd expect it to "Just Work" based on the permissions you've already configured. Requiring extra permissions makes the setup process more complicated (esp for Joomla users). Instead of debating new permissions, just follow the existing permission model.

In this case, let's close this PR. Instead, I could submit another which changes the UI's and API's to abide by the `edit message templates` permission in core.

-----

Ping @deepak-srivastava @guanhuan 
