### PR TITLE
mosaico.html - Simplify markup and visuals of the "New Mailing" screen

### DIFF
--- a/ang/crmMosaico/EditMailingCtrl/mosaico.html
+++ b/ang/crmMosaico/EditMailingCtrl/mosaico.html
@@ -1,97 +1,86 @@
 <div id="bootstrap-theme" ng-controller="CrmMosaicoMixinCtrl" class="crm-mosaico-page">
 
-  <div class="container">
-    <div class="row">
-      <div class="col-md-2 col-sm-1">&nbsp;</div>
+  <div ng-form="crmMailingSubform" >
 
-      <div ng-form="crmMailingSubform" class="col-md-8 col-sm-10">
+    <div class="panel panel-default">
+      <div class="panel-heading">{{ts('Mailing')}}</div>
+      <div class="panel-body" crm-mosaico-block-mailing crm-mailing="mailing"></div>
 
-        <div class="panel panel-default">
-          <div class="panel-heading">{{ts('Mailing')}}</div>
-          <div class="panel-body" crm-mosaico-block-mailing crm-mailing="mailing"></div>
+      <div class="panel-heading">
+        <div style="float: right" ng-show="!!mailing.template_options.mosaicoTemplate">
+          <button class="btn btn-danger-outline btn-xs" crm-confirm="{title: ts('Reset Design?'), message: ts('Resetting will destroy any content you created. You will be able to choose a new template.')}" on-yes="mosaicoCtrl.reset(mailing)">
+            <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
+            {{ts('Reset')}}
+          </button>
         </div>
-
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <div style="float: right" ng-show="!!mailing.template_options.mosaicoTemplate">
-              <button class="btn btn-danger-outline btn-xs" crm-confirm="{title: ts('Reset Design?'), message: ts('Resetting will destroy any content you created. You will be able to choose a new template.')}" on-yes="mosaicoCtrl.reset(mailing)">
-                <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
-                {{ts('Reset')}}
-              </button>
-            </div>
-            <span class="required">{{ts('Design')}}</span>
-            <div style="clear: both"></div>
-          </div>
-          <div class="panel-body">
-            <div class="row">
-              <span ng-model="body_html_defined" crm-ui-validate="!!mailing.body_html"></span>
-              <div
-                  class="col-xs-6 col-md-3 crm-mosaico-selected"
-                  crm-mosaico-template-item="{title: ts('My Design'), subtitle: mosaicoCtrl.getTemplate(mailing).type, img: mosaicoCtrl.getTemplate(mailing).thumbnail}"
-                  on-item-click="mosaicoCtrl.edit(mailing)"
-                  ng-show="!!mailing.template_options.mosaicoTemplate"
-              ></div>
-              <div ng-repeat="template in mosaicoCtrl.templates" ng-show="!mailing.template_options.mosaicoTemplate">
-                <div
-                    class="col-xs-6 col-md-3"
-                    crm-mosaico-template-item="{title: template.title, subtitle: template.type, img: template.thumbnail}"
-                    on-item-click="mosaicoCtrl.select(mailing, template)"
-                ></div>
-              </div>
-            </div>
+        <span class="required">{{ts('Design')}}</span>
+        <div style="clear: both"></div>
+      </div>
+      <div class="panel-body">
+        <div class="row">
+          <span ng-model="body_html_defined" crm-ui-validate="!!mailing.body_html"></span>
+          <div
+              class="col-xs-4 col-md-3 crm-mosaico-selected"
+              crm-mosaico-template-item="{title: ts('My Design'), subtitle: mosaicoCtrl.getTemplate(mailing).type, img: mosaicoCtrl.getTemplate(mailing).thumbnail}"
+              on-item-click="mosaicoCtrl.edit(mailing)"
+              ng-show="!!mailing.template_options.mosaicoTemplate"
+          ></div>
+          <div ng-repeat="template in mosaicoCtrl.templates" ng-show="!mailing.template_options.mosaicoTemplate">
+            <div
+                class="col-xs-4 col-md-3"
+                crm-mosaico-template-item="{title: template.title, subtitle: template.type, img: template.thumbnail}"
+                on-item-click="mosaicoCtrl.select(mailing, template)"
+            ></div>
           </div>
         </div>
-
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <div style="float: right">
-              <button class="btn btn-primary-outline btn-xs" ng-click="openAdvancedOptions(mailing)">
-                <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
-                {{ts('Advanced')}}
-              </button>
-            </div>
-            {{ts('Options')}}
-          </div>
-          <div class="panel-body">
-            <!--<div style="float:right">-->
-              <!--<button class="btn btn-primary" ng-click="openAdvancedOptions(mailing)">-->
-                <!--<span class="glyphicon glyphicon-cog" aria-hidden="true"></span>-->
-                <!--{{ts('Advanced Mailing Options')}}-->
-              <!--</button>-->
-            <!--</div>-->
-            <div crm-mosaico-block-schedule crm-mailing="mailing"/>
-          </div>
-        </div>
-
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <div class="form-group">
-              <button class="btn btn-primary"
-                      ng-disabled="block.check() || crmMailingSubform.$invalid"
-                      ng-click="submit()">
-                {{ts('Submit Mailing')}}
-              </button>
-              <button
-                  class="btn btn-primary-outline"
-                  ng-disabled="block.check()"
-                  ng-click="save().then(leave)">
-                {{ts('Save Draft')}}
-              </button>
-              <button
-                  class="btn btn-danger-outline"
-                  ng-show="checkPerm('delete in CiviMail')"
-                  ng-disabled="block.check()"
-                  crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
-                  on-yes="delete()">
-                {{ts('Delete Draft')}}
-              </button>
-            </div>
-          </div>
-        </div>
-
       </div>
 
-      <div class="col-md-2 col-sm-1">&nbsp;</div>
+      <div class="panel-heading">
+        <div style="float: right">
+          <button class="btn btn-primary-outline btn-xs" ng-click="openAdvancedOptions(mailing)">
+            <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
+            {{ts('Advanced')}}
+          </button>
+        </div>
+        {{ts('Options')}}
+      </div>
+      <div class="panel-body">
+        <!--<div style="float:right">-->
+        <!--<button class="btn btn-primary" ng-click="openAdvancedOptions(mailing)">-->
+        <!--<span class="glyphicon glyphicon-cog" aria-hidden="true"></span>-->
+        <!--{{ts('Advanced Mailing Options')}}-->
+        <!--</button>-->
+        <!--</div>-->
+        <div crm-mosaico-block-schedule crm-mailing="mailing"/>
+      </div>
     </div>
+
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <div class="form-group">
+          <button class="btn btn-primary"
+                  ng-disabled="block.check() || crmMailingSubform.$invalid"
+                  ng-click="submit()">
+            {{ts('Submit Mailing')}}
+          </button>
+          <button
+              class="btn btn-primary-outline"
+              ng-disabled="block.check()"
+              ng-click="save().then(leave)">
+            {{ts('Save Draft')}}
+          </button>
+          <button
+              class="btn btn-danger-outline"
+              ng-show="checkPerm('delete in CiviMail')"
+              ng-disabled="block.check()"
+              crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
+              on-yes="delete()">
+            {{ts('Delete Draft')}}
+          </button>
+        </div>
+      </div>
+    </div>
+
   </div>
+
 </div>


### PR DESCRIPTION
The "New Mailing" screen was using the Bootstrap grid to provide a narrower
composition page, but the positioning felt a bit wrong in some
themes/configurations, and the background/whitespace didn't match the theme.
This removes the grid and just uses panels.