### PR TITLE
Implement alternative, wizard-based layout

### DIFF
--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -9,6 +9,45 @@
 class CRM_Mosaico_Utils {
 
   /**
+   * Get a list of layout options.
+   *
+   * @return array
+   *   Array (string $machineName => string $label).
+   */
+  public static function getLayoutOptions() {
+    return array(
+      'auto' => 'Automatically select a layout',
+      'bootstrap-single' => 'Single Page (Bootstrap CSS)',
+      'bootstrap-wizard' => 'Wizard (Bootstrap CSS)',
+    );
+  }
+
+  /**
+   * Get the path to the Mosaico layout file.
+   *
+   * @return string
+   *   Ex: `~/crmMosaico/EditMailingCtrl/mosaico.html`
+   * @see getLayoutOptions()
+   */
+  public static function getLayoutPath() {
+    $layout = CRM_Core_BAO_Setting::getItem('Mosaico Preferences', 'mosaico_layout');
+    $prefix = '~/crmMosaico/EditMailingCtrl';
+
+    switch ($layout) {
+      case '':
+      case 'auto':
+      case 'bootstrap-single':
+        return "$prefix/mosaico.html";
+
+      case 'bootstrap-wizard':
+        return "$prefix/mosaico-wizard.html";
+
+      default:
+        throw new \RuntimeException("Failed to determine path for Mosaico layout ($layout)");
+    }
+  }
+
+  /**
    * Determine the URL of the (upstream) Mosaico libraries.
    *
    * @param string $preferFormat

--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -3,6 +3,9 @@
 //this may not be required as it doesn't appear to be used anywhere?
 //require_once 'packages/premailer/premailer.php';
 
+/**
+ * Class CRM_Mosaico_Utils
+ */
 class CRM_Mosaico_Utils {
 
   /**
@@ -126,7 +129,7 @@ class CRM_Mosaico_Utils {
           $file = array(
             "name" => $file_name,
             "url" => $config['BASE_URL'] . $config['UPLOADS_DIR'] . $file_name,
-            "size" => $size
+            "size" => $size,
           );
 
           if (file_exists($config['BASE_DIR'] . $config['THUMBNAILS_DIR'] . $file_name)) {
@@ -136,7 +139,8 @@ class CRM_Mosaico_Utils {
           $files[] = $file;
         }
       }
-    } else if (!empty($_FILES)) {
+    }
+    elseif (!empty($_FILES)) {
       foreach ($_FILES["files"]["error"] as $key => $error) {
         if ($error == UPLOAD_ERR_OK) {
           $tmp_name = $_FILES["files"]["tmp_name"][$key];
@@ -164,15 +168,17 @@ class CRM_Mosaico_Utils {
               "name" => $file_name,
               "url" => $config['BASE_URL'] . $config['UPLOADS_DIR'] . $file_name,
               "size" => $size,
-              "thumbnailUrl" => $config['BASE_URL'] . $config['THUMBNAILS_URL'] . $file_name
+              "thumbnailUrl" => $config['BASE_URL'] . $config['THUMBNAILS_URL'] . $file_name,
             );
 
             $files[] = $file;
-          } else {
+          }
+          else {
             $http_return_code = 500;
             return;
           }
-        } else {
+        }
+        else {
           $http_return_code = 400;
           return;
         }
@@ -217,7 +223,7 @@ class CRM_Mosaico_Utils {
             array("x" => $x, "y" => $y),
             array("x" => $x + $size, "y" => $y),
             array("x" => $x + $size * 2, "y" => $y + $size),
-            array("x" => $x + $size * 2, "y" => $y + $size * 2)
+            array("x" => $x + $size * 2, "y" => $y + $size * 2),
           );
 
           $draw->polygon($points);
@@ -225,7 +231,7 @@ class CRM_Mosaico_Utils {
           $points = array(
             array("x" => $x, "y" => $y + $size),
             array("x" => $x + $size, "y" => $y + $size * 2),
-            array("x" => $x, "y" => $y + $size * 2)
+            array("x" => $x, "y" => $y + $size * 2),
           );
 
           $draw->polygon($points);
@@ -485,10 +491,10 @@ class CRM_Mosaico_Utils {
         // In order to use last parameter(best fit), this will make right scale, as true in 'resizeImage' menthod, we can't have 0 for height
         // hence retreiving height from image
         // more details about best fit http://php.net/manual/en/imagick.resizeimage.php
-        $image->resizeImage( $width, $image->getImageHeight(), Imagick::FILTER_LANCZOS, 1.0, TRUE );
+        $image->resizeImage($width, $image->getImageHeight(), Imagick::FILTER_LANCZOS, 1.0, TRUE);
       }
-      else // $method == "cover"
-      {
+      else {
+        // assert: $method == "cover"
         $image_geometry = $image->getImageGeometry();
 
         $width_ratio = $image_geometry["width"] / $width;

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ To send a new mailing, simply navigate to "Mailings => New Mailing". The CiviMai
 
 Optionally, you may design reusable templates by navigating to "Mailings => Mosaico Templates".
 
+When composing a new mailing, the default layout uses a single page.  To
+change the layout, you can update the setting `mosaico_layout` to
+`bootstrap-wizard` or `bootstrap-single`, e.g.
+
+```
+cv api setting.create mosaico_layout=bootstrap-wizard
+```
+
 ### Having issues with this extension?
 
 Please make sure you have followed installation instructions. 

--- a/ang/crmMosaico.css
+++ b/ang/crmMosaico.css
@@ -18,7 +18,7 @@
     border: 1px dotted;
 }
 
-#bootstrap-theme.crm-mosaico-page select[name=reply_id],
+#bootstrap-theme.crm-mosaico-page input[name=campaign],
 #bootstrap-theme.crm-mosaico-page select[name=optout_id],
 #bootstrap-theme.crm-mosaico-page select[name=resubscribe_id],
 #bootstrap-theme.crm-mosaico-page select[name=unsubscribe_id],

--- a/ang/crmMosaico.css
+++ b/ang/crmMosaico.css
@@ -34,3 +34,7 @@
 #bootstrap-theme.crm-mosaico-page .crm-mailing-recipients-row select {
     width: 70%;
 }
+
+#bootstrap-theme.crm-mosaico-wizard {
+    padding: 0.7em;
+}

--- a/ang/crmMosaico/EditMailingCtrl/mosaico-wizard.html
+++ b/ang/crmMosaico/EditMailingCtrl/mosaico-wizard.html
@@ -1,0 +1,91 @@
+<div id="bootstrap-theme" ng-controller="CrmMosaicoMixinCtrl" class="crm-mosaico-page crm-mosaico-wizard">
+
+  <div crmb-wizard crmb-wizard-ctrl="crmbWizardCtrl">
+    <div crmb-wizard-step crm-title="ts('Mailing')" ng-form="mailingForm">
+      <div crm-mosaico-block-mailing crm-mailing="mailing"></div>
+    </div>
+
+    <div crmb-wizard-step crm-title="ts('Design')" ng-form="designForm">
+      <div class="row">
+        <span ng-model="body_html_defined" crm-ui-validate="!!mailing.body_html"></span>
+        <div
+            class="col-xs-4 col-md-3 crm-mosaico-selected"
+            crm-mosaico-template-item="{title: ts('My Design'), subtitle: mosaicoCtrl.getTemplate(mailing).type, img: mosaicoCtrl.getTemplate(mailing).thumbnail}"
+            on-item-click="mosaicoCtrl.edit(mailing)"
+            on-item-reset="mosaicoCtrl.reset(mailing)"
+            ng-show="!!mailing.template_options.mosaicoTemplate"
+        ></div>
+        <div ng-repeat="template in mosaicoCtrl.templates" ng-show="!mailing.template_options.mosaicoTemplate">
+          <div
+              class="col-xs-4 col-md-3"
+              crm-mosaico-template-item="{title: template.title, subtitle: template.type, img: template.thumbnail}"
+              on-item-click="mosaicoCtrl.select(mailing, template)"
+          ></div>
+        </div>
+      </div>
+    </div>
+
+    <div crmb-wizard-step crm-title="ts('Options')" ng-form="optionsForm">
+      <div style="float: right">
+        <button class="btn btn-primary" ng-click="openAdvancedOptions(mailing)">
+          <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
+          {{ts('Advanced')}}
+        </button>
+      </div>
+      <div crm-mosaico-block-schedule crm-mailing="mailing"/>
+    </div>
+
+    <button
+        class="btn btn-secondary-outline"
+        crmb-wizard-button-position="left"
+        ng-click="crmbWizardCtrl.previous()"
+        ng-show="!crmbWizardCtrl.$first()">
+      <span class="btn-icon"><i class="fa fa-chevron-left"></i></span>
+      {{ts('Back')}}
+    </button>
+
+    <button
+        class="btn btn-danger-outline"
+        crmb-wizard-button-position="left"
+        ng-show="checkPerm('delete in CiviMail') && crmbWizardCtrl.$first()"
+        ng-disabled="block.check()"
+        crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
+        on-yes="delete()">
+      <span class="btn-icon"><i class="fa fa-trash"></i></span>
+      {{ts('Delete Draft')}}
+    </button>
+
+    <button
+        class="btn btn-secondary-outline"
+        crmb-wizard-button-position="right"
+        ng-disabled="block.check()"
+        ng-click="save().then(leave)">
+      <span class="btn-icon"><i class="fa fa-floppy-o"></i></span>
+      {{ts('Save Draft')}}
+    </button>
+
+    <!-- ng-disabled and Bootstrap buttons don't seem to work together, hence btn-secondary -->
+    <button
+        class="btn btn-primary"
+        crmb-wizard-button-position="right"
+        title="{{!crmbWizardCtrl.$validStep() ? ts('Complete all required fields first') : ts('Next step')}}"
+        ng-click="crmbWizardCtrl.next()"
+        ng-show="!crmbWizardCtrl.$last()"
+        ng-disabled="!crmbWizardCtrl.$validStep()">
+      <span class="btn-icon"><i class="fa fa-chevron-right"></i></span>
+      {{ts('Continue')}}
+    </button>
+
+    <button
+        class="btn btn-success"
+        crmb-wizard-button-position="right"
+        ng-show="crmbWizardCtrl.$last()"
+        ng-disabled="block.check() || optionsForm.$invalid"
+        ng-click="submit()">
+      <span class="btn-icon"><i class="fa fa-send"></i></span>
+      {{ts('Submit Mailing')}}
+    </button>
+
+  </div>
+
+</div>

--- a/ang/crmMosaico/EditMailingCtrl/mosaico.html
+++ b/ang/crmMosaico/EditMailingCtrl/mosaico.html
@@ -61,12 +61,14 @@
           <button class="btn btn-primary"
                   ng-disabled="block.check() || crmMailingSubform.$invalid"
                   ng-click="submit()">
+            <span class="btn-icon"><i class="fa fa-send"></i></span>
             {{ts('Submit Mailing')}}
           </button>
           <button
               class="btn btn-primary-outline"
               ng-disabled="block.check()"
               ng-click="save().then(leave)">
+            <span class="btn-icon"><i class="fa fa-floppy-o"></i></span>
             {{ts('Save Draft')}}
           </button>
           <button
@@ -75,6 +77,7 @@
               ng-disabled="block.check()"
               crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
               on-yes="delete()">
+            <span class="btn-icon"><i class="fa fa-trash"></i></span>
             {{ts('Delete Draft')}}
           </button>
         </div>

--- a/ang/crmMosaico/TemplateItem.html
+++ b/ang/crmMosaico/TemplateItem.html
@@ -1,6 +1,7 @@
 <span class="thumbnail crm-mosaico-template-item">
   <img alt="{{myOptions.title}}" src="{{myOptions.img}}" style="height: 180px; width: 100%; display: block;" ng-click="fireAction('onItemClick')">
     <a style="float: right;" class="btn btn-xs btn-danger-outline glyphicon glyphicon-remove-sign" title="Delete" ng-if="hasAction('onItemDelete')" crm-confirm="{type: 'delete', obj: {title: 'template'}}" on-yes="fireAction('onItemDelete')"></a>
+    <a style="float: right;" class="btn btn-xs btn-danger-outline glyphicon glyphicon-remove-sign" title="Reset" ng-if="hasAction('onItemReset')" crm-confirm="{title: ts('Reset'), message: ts('Are you sure you want to reset this?')}" on-yes="fireAction('onItemReset')"></a>
     <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-duplicate" title="Copy" ng-if="hasAction('onItemCopy')" ng-click="fireAction('onItemCopy')"></a>
     <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-wrench" title="Settings" ng-if="hasAction('onItemSettings')" ng-click="fireAction('onItemSettings')"></a>
     <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-search" title="Preview" ng-if="hasAction('onItemPreview')" ng-click="fireAction('onItemPreview')"></a>

--- a/ang/crmbWizard.ang.php
+++ b/ang/crmbWizard.ang.php
@@ -1,0 +1,24 @@
+<?php
+// This file declares an Angular module which can be autoloaded
+// in CiviCRM. See also:
+// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+
+return array (
+  'js' => 
+  array (
+    0 => 'ang/crmbWizard.js',
+    1 => 'ang/crmbWizard/*.js',
+    2 => 'ang/crmbWizard/*/*.js',
+  ),
+  'css' => 
+  array (
+    0 => 'ang/crmbWizard.css',
+  ),
+  'partials' => 
+  array (
+    0 => 'ang/crmbWizard',
+  ),
+  'settings' => 
+  array (
+  ),
+);

--- a/ang/crmbWizard.css
+++ b/ang/crmbWizard.css
@@ -1,0 +1,3 @@
+.crmb-wizard-body {
+    margin-top: 0.7em;
+}

--- a/ang/crmbWizard.js
+++ b/ang/crmbWizard.js
@@ -1,0 +1,166 @@
+(function(angular, $, _) {
+  // Declare a list of dependencies.
+  angular.module('crmbWizard', [
+    'crmUi', 'crmUtil'
+  ]);
+
+
+  // example: <div crmb-wizard-bootstrap="myWizardCtrl"><div crmb-wizard-bootstrap-step crm-title="ts('Step 1')">...</div><div crmb-wizard-bootstrap-step crm-title="ts('Step 2')">...</div></div>
+  // example with custom nav classes: <div crmb-wizard-bootstrap crmb-wizard-bootstrap-nav-class="ng-animate-out ...">...</div>
+  // Note: "myWizardCtrl" has various actions/properties like next() and $first().
+  // WISHLIST: Allow each step to determine if it is "complete" / "valid" / "selectable"
+  // WISHLIST: Allow each step to enable/disable (show/hide) itself
+  angular.module('crmbWizard').directive('crmbWizard', function() {
+      return {
+        restrict: 'EA',
+        scope: {
+          crmbWizard: '@',
+          crmbWizardCtrl: '=',
+          crmbWizardNavClass: '@' // string, A list of classes that will be added to the nav items
+        },
+        templateUrl: '~/crmbWizard/layout.html',
+        transclude: true,
+        controllerAs: 'crmbWizardCtrl',
+        controller: function($scope, $parse) {
+          var steps = $scope.steps = []; // array<$scope>
+          var crmbWizardCtrl = this;
+          var maxVisited = 0;
+          var selectedIndex = null;
+
+          var findIndex = function() {
+            var found = null;
+            angular.forEach(steps, function(step, stepKey) {
+              if (step.selected) found = stepKey;
+            });
+            return found;
+          };
+
+          /// @return int the index of the current step
+          this.$index = function() { return selectedIndex; };
+          /// @return bool whether the currentstep is first
+          this.$first = function() { return this.$index() === 0; };
+          /// @return bool whether the current step is last
+          this.$last = function() { return this.$index() === steps.length -1; };
+          this.$maxVisit = function() { return maxVisited; };
+          this.$validStep = function() {
+            return steps[selectedIndex] && steps[selectedIndex].isStepValid();
+          };
+          this.iconFor = function(index) {
+            if (index < this.$index()) return '√';
+            if (index === this.$index()) return '»';
+            return ' ';
+          };
+          this.isSelectable = function(step) {
+            if (step.selected) return false;
+            var result = false;
+            angular.forEach(steps, function(otherStep, otherKey) {
+              if (step === otherStep && otherKey <= maxVisited) result = true;
+            });
+            return result;
+          };
+
+          /*** @param Object step the $scope of the step */
+          this.select = function(step) {
+            angular.forEach(steps, function(otherStep, otherKey) {
+              otherStep.selected = (otherStep === step);
+              if (otherStep === step && maxVisited < otherKey) maxVisited = otherKey;
+            });
+            selectedIndex = findIndex();
+          };
+          /*** @param Object step the $scope of the step */
+          this.add = function(step) {
+            if (steps.length === 0) {
+              step.selected = true;
+              selectedIndex = 0;
+            }
+            steps.push(step);
+            steps.sort(function(a,b){
+              return a.crmbWizardStep - b.crmbWizardStep;
+            });
+            selectedIndex = findIndex();
+          };
+          this.remove = function(step) {
+            var key = null;
+            angular.forEach(steps, function(otherStep, otherKey) {
+              if (otherStep === step) key = otherKey;
+            });
+            if (key !== null) {
+              steps.splice(key, 1);
+            }
+          };
+          this.goto = function(index) {
+            if (index < 0) index = 0;
+            if (index >= steps.length) index = steps.length-1;
+            this.select(steps[index]);
+          };
+          this.previous = function() { this.goto(this.$index()-1); };
+          this.next = function() { this.goto(this.$index()+1); };
+          if ($scope.crmbWizard) {
+            $parse($scope.crmbWizard).assign($scope.$parent, this);
+          }
+
+          $scope.crmbWizardCtrl = this;
+        },
+        link: function (scope, element, attrs) {
+          scope.ts = CRM.ts(null);
+        }
+      };
+    });
+
+  // Use this to add extra markup to wizard
+  angular.module('crmbWizard').directive('crmbWizardButtonPosition', function() {
+    return {
+      require: '^crmbWizard',
+      restrict: 'EA',
+      scope: {
+        crmbWizardButtonPosition: '@'
+      },
+      template: '<span ng-transclude></span>',
+      transclude: true,
+      link: function (scope, element, attrs, crmbWizardCtrl) {
+        var pos = scope.crmbWizardButtonPosition;
+        var realButtonsEl = $(element).closest('.crmb-wizard').find('.crmb-wizard-button-' + pos);
+        if (pos === 'right') realButtonsEl.append(' ');
+        element.appendTo(realButtonsEl);
+        if (pos === 'left') realButtonsEl.append(' ');
+      }
+    };
+  });
+
+
+  // example: <div crmb-wizard-bootstrap-step crm-title="ts('My Title')" ng-form="mySubForm">...content...</div>
+  // If there are any conditional steps, then be sure to set a weight explicitly on *all* steps to maintain ordering.
+  // example: <div crmb-wizard-bootstrap-step="100" crm-title="..." ng-if="...">...content...</div>
+  // example with custom classes: <div crmb-wizard-bootstrap-step="100" crmb-wizard-bootstrap-step-class="ng-animate-out ...">...content...</div>
+  angular.module('crmbWizard').directive('crmbWizardStep', function() {
+    var nextWeight = 1;
+    return {
+      require: ['^crmbWizard', 'form'],
+      restrict: 'EA',
+      scope: {
+        crmTitle: '@', // expression, evaluates to a printable string
+        crmbWizardStep: '@', // int, a weight which determines the ordering of the steps
+        crmbWizardStepClass: '@' // string, A list of classes that will be added to the template
+      },
+      template: '<div class="crmb-wizard-step {{crmbWizardStepClass}}" ng-show="selected" ng-transclude/></div>',
+      transclude: true,
+      link: function (scope, element, attrs, ctrls) {
+        var crmbWizardCtrl = ctrls[0], form = ctrls[1];
+        if (scope.crmbWizardStep) {
+          scope.crmbWizardStep = parseInt(scope.crmbWizardStep);
+        } else {
+          scope.crmbWizardStep = nextWeight++;
+        }
+        scope.isStepValid = function() {
+          return form.$valid;
+        };
+        crmbWizardCtrl.add(scope);
+        scope.$on('$destroy', function(){
+          crmbWizardCtrl.remove(scope);
+        });
+      }
+    };
+  })
+
+
+})(angular, CRM.$, CRM._);

--- a/ang/crmbWizard/layout.html
+++ b/ang/crmbWizard/layout.html
@@ -1,0 +1,36 @@
+<div class="crmb-wizard">
+
+  <div class="panel">
+    <div class="panel-body">
+      <ul class="nav nav-pills">
+        <li ng-repeat="step in steps" ng-class="{'active':step.selected, 'disabled': !crmbWizardCtrl.isSelectable(step)}" class="{{crmbWizardNavClass}}">
+          <a href="" ng-click="crmbWizardCtrl.isSelectable(step) && crmbWizardCtrl.select(step)">
+            {{crmbWizardCtrl.iconFor($index)}}
+            {{1 + $index}}.
+            {{step.$parent.$eval(step.crmTitle)}}</a>
+          <!-- Don't know a good way to localize text like "1. Title" -->
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-body">
+      <div class="crmb-wizard-body" ng-transclude/>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-body">
+      <div class="row">
+        <div class="col-md-6" style="text-align: left">
+          <div class="crmb-wizard-button-left"></div>
+        </div>
+        <div class="col-md-6" style="text-align: right">
+          <div class="crmb-wizard-button-right"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/mosaico.php
+++ b/mosaico.php
@@ -354,8 +354,12 @@ function mosaico_civicrm_mailingTemplateTypes(&$types) {
   }
   $messages = array();
   mosaico_civicrm_check($messages);
+
+  // v4.6 compat
+  require_once 'CRM/Mosaico/Utils.php';
+
   $editorUrl = empty($messages)
-    ? '~/crmMosaico/EditMailingCtrl/mosaico.html'
+    ? CRM_Mosaico_Utils::getLayoutPath()
     : '~/crmMosaico/requirements.html';
 
   $types[] = array(

--- a/settings/Mosaico.setting.php
+++ b/settings/Mosaico.setting.php
@@ -1,0 +1,24 @@
+<?php
+return array(
+  'mosaico_layout' => array(
+    'group_name' => 'Mosaico Preferences',
+    'group' => 'mosaico',
+    'name' => 'mosaico_layout',
+
+    'type' => 'String',
+    'html_type' => 'Select',
+    'html_attributes' => array(
+      'class' => 'crm-select2',
+    ),
+    'pseudoconstant' => array(
+      'callback' => 'CRM_Mosaico_Utils::getLayoutOptions',
+    ),
+    'default' => 'auto',
+    'add' => '4.7',
+    'title' => 'Editor layout',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => NULL,
+    'help_text' => NULL,
+  ),
+);


### PR DESCRIPTION
As with the "New Mailing" screen in CiviMail, the general layout of the "New
Mailing" screen in Mosaico has been somewhat contentious in design
discussions.

I'm personally of the opinion that the existing/single-page layout is better
because you don't have to click around as much (and the quantity of inputs
is still manageable).  However, this allows folks to try out the different
options.

As described in the updated README, you can switch the layouts by calling:

```
cv api setting.create mosaico_layout=bootstrap-single
cv api setting.create mosaico_layout=bootstrap-wizard
```