### PR TITLE
info.xml - Bump version to 2.0-beta1 (#105)

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2016-08-26</releaseDate>
-  <version>1.0-beta1</version>
+  <version>2.0-beta1</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
Per discusison in #105, we wanted to change the master version number to
2.0-beta1 to indicate the major changes from 1.0-beta1.