### PR TITLE
Make image folders on-demand

### DIFF
--- a/CRM/Mosaico/Page/Index.php
+++ b/CRM/Mosaico/Page/Index.php
@@ -30,33 +30,7 @@ class CRM_Mosaico_Page_Index extends CRM_Core_Page {
         $messages[] = new CRM_Utils_Check_Message('mosaico_base_url', ts('BASE_URL seems incorrect - %1. Images when uploaded, may not appear correctly as thumbnails. Make sure "Image Upload URL" is configured correctly with Administer » System Settings » Resouce URLs.', array(1 => $mConfig['BASE_URL'])), ts('Incorrect image upload url'));
       }
     }
-
-    // Check if UPLOADS directory exists and create it if it doesn't
-    if (!is_dir($mConfig['BASE_DIR'] . $mConfig['UPLOADS_DIR'])) {
-      if (!mkdir($mConfig['BASE_DIR'] . $mConfig['UPLOADS_DIR'], 0775, TRUE)) {
-        $messages[] = new CRM_Utils_Check_Message('mosaico_uploads_dir', ts('%1 not writable or configured.', array(1 => $mConfig['BASE_DIR'] . $mConfig['UPLOADS_DIR'])), ts('UPLOADS_DIR not writable or configured'));
-      }
-    } elseif (!is_writable($mConfig['BASE_DIR'] . $mConfig['UPLOADS_DIR'])) {
-      $messages[] = new CRM_Utils_Check_Message('mosaico_uploads_dir', ts('%1 not writable or configured.', array(1 => $mConfig['BASE_DIR'] . $mConfig['UPLOADS_DIR'])), ts('UPLOADS_DIR not writable or configured'));
-    }
-
-    // Check if uploads/STATIC directory exists and create it if it doesn't
-    if (!is_dir($mConfig['BASE_DIR'] . $mConfig['STATIC_DIR'])) {
-      if (!mkdir($mConfig['BASE_DIR'] . $mConfig['STATIC_DIR'], 0775, TRUE)) {
-        $messages[] = new CRM_Utils_Check_Message('mosaico_static_dir', ts('%1 not writable or configured.', array(1 => $mConfig['BASE_DIR'] . $mConfig['STATIC_DIR'])), ts('STATIC_DIR not writable or configured'));
-      }
-    } elseif (!is_writable($mConfig['BASE_DIR'] . $mConfig['STATIC_DIR'])) {
-      $messages[] = new CRM_Utils_Check_Message('mosaico_static_dir', ts('%1 not writable or configured.', array(1 => $mConfig['BASE_DIR'] . $mConfig['STATIC_DIR'])), ts('STATIC_DIR not writable or configured'));
-    }
-
-    // Check if uploads/THUMBNAILS directory exists and create it if it doesn't
-    if (!is_dir($mConfig['BASE_DIR'] . $mConfig['THUMBNAILS_DIR'])) {
-      if (!mkdir($mConfig['BASE_DIR'] . $mConfig['THUMBNAILS_DIR'], 0775, TRUE)) {
-        $messages[] = new CRM_Utils_Check_Message('mosaico_thumbnails_dir', ts('%1 not writable or configured.', array(1 => $mConfig['BASE_DIR'] . $mConfig['THUMBNAILS_DIR'])), ts('THUMBNAILS_DIR not writable or configured'));
-      }
-    } elseif (!is_writable($mConfig['BASE_DIR'] . $mConfig['THUMBNAILS_DIR'])) {
-      $messages[] = new CRM_Utils_Check_Message('mosaico_thumbnails_dir', ts('%1 not writable or configured.', array(1 => $mConfig['BASE_DIR'] . $mConfig['THUMBNAILS_DIR'])), ts('THUMBNAILS_DIR not writable or configured'));
-    }
+    _mosaico_civicrm_check_dirs($messages);
 
     // check if Mosaico extension is in the correctly named extension directory
     $extDirName = basename(dirname(dirname(dirname(dirname(__FILE__)))));

--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -151,6 +151,14 @@ class CRM_Mosaico_Utils {
 
     global $http_return_code;
 
+    $messages = array();
+    _mosaico_civicrm_check_dirs($messages);
+    if (!empty($messages)) {
+      CRM_Core_Error::debug_log_message('Mosaico uploader failed. Check system status for directory errors.');
+      $http_return_code = 500;
+      return;
+    }
+
     $files = array();
 
     if ($_SERVER["REQUEST_METHOD"] == "GET") {

--- a/mosaico.php
+++ b/mosaico.php
@@ -292,6 +292,42 @@ function mosaico_civicrm_check(&$messages) {
       \Psr\Log\LogLevel::CRITICAL
     );
   }
+
+  _mosaico_civicrm_check_dirs($messages);
+}
+
+function _mosaico_civicrm_check_dirs(&$messages) {
+  $mConfig = CRM_Mosaico_Utils::getConfig();
+
+  // Check if UPLOADS directory exists and create it if it doesn't
+  if (!is_dir($mConfig['BASE_DIR'] . $mConfig['UPLOADS_DIR'])) {
+    if (!mkdir($mConfig['BASE_DIR'] . $mConfig['UPLOADS_DIR'], 0775, TRUE)) {
+      $messages[] = new CRM_Utils_Check_Message('mosaico_uploads_dir', ts('%1 not writable or configured.', array(1 => $mConfig['BASE_DIR'] . $mConfig['UPLOADS_DIR'])), ts('UPLOADS_DIR not writable or configured'));
+    }
+  }
+  elseif (!is_writable($mConfig['BASE_DIR'] . $mConfig['UPLOADS_DIR'])) {
+    $messages[] = new CRM_Utils_Check_Message('mosaico_uploads_dir', ts('%1 not writable or configured.', array(1 => $mConfig['BASE_DIR'] . $mConfig['UPLOADS_DIR'])), ts('UPLOADS_DIR not writable or configured'));
+  }
+
+  // Check if uploads/STATIC directory exists and create it if it doesn't
+  if (!is_dir($mConfig['BASE_DIR'] . $mConfig['STATIC_DIR'])) {
+    if (!mkdir($mConfig['BASE_DIR'] . $mConfig['STATIC_DIR'], 0775, TRUE)) {
+      $messages[] = new CRM_Utils_Check_Message('mosaico_static_dir', ts('%1 not writable or configured.', array(1 => $mConfig['BASE_DIR'] . $mConfig['STATIC_DIR'])), ts('STATIC_DIR not writable or configured'));
+    }
+  }
+  elseif (!is_writable($mConfig['BASE_DIR'] . $mConfig['STATIC_DIR'])) {
+    $messages[] = new CRM_Utils_Check_Message('mosaico_static_dir', ts('%1 not writable or configured.', array(1 => $mConfig['BASE_DIR'] . $mConfig['STATIC_DIR'])), ts('STATIC_DIR not writable or configured'));
+  }
+
+  // Check if uploads/THUMBNAILS directory exists and create it if it doesn't
+  if (!is_dir($mConfig['BASE_DIR'] . $mConfig['THUMBNAILS_DIR'])) {
+    if (!mkdir($mConfig['BASE_DIR'] . $mConfig['THUMBNAILS_DIR'], 0775, TRUE)) {
+      $messages[] = new CRM_Utils_Check_Message('mosaico_thumbnails_dir', ts('%1 not writable or configured.', array(1 => $mConfig['BASE_DIR'] . $mConfig['THUMBNAILS_DIR'])), ts('THUMBNAILS_DIR not writable or configured'));
+    }
+  }
+  elseif (!is_writable($mConfig['BASE_DIR'] . $mConfig['THUMBNAILS_DIR'])) {
+    $messages[] = new CRM_Utils_Check_Message('mosaico_thumbnails_dir', ts('%1 not writable or configured.', array(1 => $mConfig['BASE_DIR'] . $mConfig['THUMBNAILS_DIR'])), ts('THUMBNAILS_DIR not writable or configured'));
+  }
 }
 
 /**


### PR DESCRIPTION
The previous code for auto-creating folders fired as part of
`CRM_Mosaico_Page_Index`.  However, in v2.0, this page isn't typically used
as an entry-point. When attempting to upload an image on a new installation,
the user would get an error:

```
Unexpected upload error (SyntaxError: Unexpected end of JSON input)
```

This PR moves the mkdir logic from `CRM_Mosaico_Page_Index` to a standalone
helper function, `_mosaico_civicrm_check_dirs()`. This helper is called
in several places:

 * When someone visits CRM_Mosaico_Page_Index (as before)
 * When someone uploads an image to Mosaico
 * During system check