### PR TITLE
Simplify/align permission model

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ cd uk.co.vedaconsulting.mosaico
 
 ### Usage
 
-In your CMS permissions, grant backend users the new permission to `access CiviCRM Mosaico`.
-
 If you haven't used Mosaico before, consult the the demo and tutorial materials from http://mosaico.io/index.html.
 
 To send a new mailing, simply navigate to "Mailings => New Mailing". The CiviMail-Mosaico UI should appear.

--- a/ang/crmMosaico.ang.php
+++ b/ang/crmMosaico.ang.php
@@ -20,5 +20,6 @@ return array (
   ),
   'settings' => 
   array (
+    'canDelete' => Civi::service('civi_api_kernel')->runAuthorize('MosaicoTemplate', 'delete', array('version' => 3, 'check_permissions' => 1)),
   ),
 );

--- a/ang/crmMosaico/ListCtrl.html
+++ b/ang/crmMosaico/ListCtrl.html
@@ -15,6 +15,7 @@
               on-item-copy="copyTpl(template)"
               on-item-settings="renameTpl(template)"
               on-item-delete="deleteTpl(template)"
+              check-item-delete="canDelete()"
           ></div>
         </div>
       </div>

--- a/ang/crmMosaico/ListCtrl.js
+++ b/ang/crmMosaico/ListCtrl.js
@@ -118,6 +118,10 @@
       );
     };
 
+    $scope.canDelete = function() {
+      return CRM.crmMosaico.canDelete;
+    };
+
   });
 
 })(angular, CRM.$, CRM._);

--- a/ang/crmMosaico/TemplateItem.html
+++ b/ang/crmMosaico/TemplateItem.html
@@ -1,10 +1,10 @@
 <span class="thumbnail crm-mosaico-template-item">
   <img alt="{{myOptions.title}}" src="{{myOptions.img}}" style="height: 180px; width: 100%; display: block;" ng-click="fireAction('onItemClick')">
-    <a style="float: right;" class="btn btn-xs btn-danger-outline glyphicon glyphicon-remove-sign" title="Delete" ng-if="hasAction('onItemDelete')" crm-confirm="{type: 'delete', obj: {title: 'template'}}" on-yes="fireAction('onItemDelete')"></a>
-    <a style="float: right;" class="btn btn-xs btn-danger-outline glyphicon glyphicon-remove-sign" title="Reset" ng-if="hasAction('onItemReset')" crm-confirm="{title: ts('Reset'), message: ts('Are you sure you want to reset this?')}" on-yes="fireAction('onItemReset')"></a>
-    <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-duplicate" title="Copy" ng-if="hasAction('onItemCopy')" ng-click="fireAction('onItemCopy')"></a>
-    <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-wrench" title="Settings" ng-if="hasAction('onItemSettings')" ng-click="fireAction('onItemSettings')"></a>
-    <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-search" title="Preview" ng-if="hasAction('onItemPreview')" ng-click="fireAction('onItemPreview')"></a>
+    <a style="float: right;" class="btn btn-xs btn-danger-outline glyphicon glyphicon-remove-sign" title="Delete" ng-if="hasAction('ItemDelete')" crm-confirm="{type: 'delete', obj: {title: 'template'}}" on-yes="fireAction('onItemDelete')"></a>
+    <a style="float: right;" class="btn btn-xs btn-danger-outline glyphicon glyphicon-remove-sign" title="Reset" ng-if="hasAction('ItemReset')" crm-confirm="{title: ts('Reset'), message: ts('Are you sure you want to reset this?')}" on-yes="fireAction('onItemReset')"></a>
+    <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-duplicate" title="Copy" ng-if="hasAction('ItemCopy')" ng-click="fireAction('onItemCopy')"></a>
+    <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-wrench" title="Settings" ng-if="hasAction('ItemSettings')" ng-click="fireAction('onItemSettings')"></a>
+    <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-search" title="Preview" ng-if="hasAction('ItemPreview')" ng-click="fireAction('onItemPreview')"></a>
     <a ng-click="fireAction('onItemClick')">
       {{myOptions.title}}
       <small ng-if="myOptions.subtitle"><br/>{{myOptions.subtitle}}</small>

--- a/ang/crmMosaico/TemplateItem.js
+++ b/ang/crmMosaico/TemplateItem.js
@@ -1,6 +1,7 @@
 (function(angular, $, _) {
   // "crmMosaicoTemplateItem" displays an actionable thumbnail.
-  // To specify action handlers, use `on-item-click` and `on-item-preview`.
+  // To specify action handlers, use `on-item-click`, `on-item-preview`, etal.
+  // To conditionally enable/disable actions, use `check-item-click`, `check-item-preview`, etal.
   // Example usage: <div crm-mosaico-template-item="{title: 1, subtitle: 2, thumbnail: 3}" on-item-click="alert('Click')" on-item-preview="alert('Preview')"></div>
   angular.module('crmMosaico').directive('crmMosaicoTemplateItem', function() {
     return {
@@ -15,7 +16,13 @@
           $scope.myOptions = newValue;
         });
         $scope.hasAction = function hasAction(action) {
-          return !!$attr[action];
+          if (!$attr['on'+action]) return false;
+          if ($attr['check'+action]) {
+            if (!$scope.$parent.$eval($attr['check'+action])) {
+              return false;
+            }
+          }
+          return true;
         };
         $scope.fireAction = function fireAction(action) {
           $scope.$parent.$eval($attr[action], {});

--- a/xml/Menu/mosaico.xml
+++ b/xml/Menu/mosaico.xml
@@ -4,43 +4,43 @@
     <path>civicrm/mosaico/ajax/setmd</path>
     <page_callback>CRM_Mosaico_Utils::setMetadata</page_callback>
     <title>Integration with Mosaico</title>
-    <access_arguments>access CiviCRM Mosaico</access_arguments>
+    <access_arguments>edit message templates</access_arguments>
   </item>
   <item>
     <path>civicrm/mosaico/ajax/copy</path>
     <page_callback>CRM_Mosaico_Utils::copyTemplate</page_callback>
     <title>Integration with Mosaico</title>
-    <access_arguments>access CiviCRM Mosaico</access_arguments>
+    <access_arguments>edit message templates</access_arguments>
   </item> 
   <item>
     <path>civicrm/mosaico</path>
     <page_callback>CRM_Mosaico_Page_Index</page_callback>
     <title>Message Template Builder</title>
-    <access_arguments>access CiviCRM Mosaico</access_arguments>
+    <access_arguments>edit message templates</access_arguments>
   </item>
   <item>
     <path>civicrm/mosaico/index</path>
     <page_callback>CRM_Mosaico_Page_Index</page_callback>
     <title>Message Template Builder</title>
-    <access_arguments>access CiviCRM Mosaico</access_arguments>
+    <access_arguments>edit message templates</access_arguments>
   </item>
   <item>
     <path>civicrm/mosaico/editor</path>
     <page_callback>CRM_Mosaico_Page_Editor</page_callback>
     <title>Integration with Mosaico</title>
-    <access_arguments>access CiviCRM Mosaico</access_arguments>
+    <access_arguments>edit message templates</access_arguments>
   </item>
   <item>
     <path>civicrm/mosaico/iframe</path>
     <page_callback>CRM_Mosaico_Page_EditorIframe</page_callback>
     <title>Integration with Mosaico</title>
-    <access_arguments>access CiviCRM Mosaico</access_arguments>
+    <access_arguments>access CiviMail;create mailings;edit message templates</access_arguments>
   </item>
   <item>
     <path>civicrm/mosaico/upload</path>
     <page_callback>CRM_Mosaico_Utils::processUpload</page_callback>
     <title>Integration with Mosaico</title>
-    <access_arguments>access CiviCRM Mosaico</access_arguments>
+    <access_arguments>access CiviMail;create mailings;edit message templates</access_arguments>
   </item>
   <item>
     <path>civicrm/mosaico/img</path>
@@ -53,24 +53,24 @@
     <path>civicrm/mosaico/dl</path>
     <page_callback>CRM_Mosaico_Utils::processDl</page_callback>
     <title>Integration with Mosaico</title>
-    <access_arguments>access CiviCRM Mosaico</access_arguments>
+    <access_arguments>access CiviMail;create mailings;edit message templates</access_arguments>
   </item>
   <item>
     <path>civicrm/mosaico/ajax/getallmd</path>
     <page_callback>CRM_Mosaico_Utils::getAllMetadata</page_callback>
     <title>Integration with Mosaico</title>
-    <access_arguments>access CiviCRM Mosaico</access_arguments>
+    <access_arguments>edit message templates</access_arguments>
   </item>
   <item>
     <path>civicrm/mosaico/ajax/edit</path>
     <page_callback>CRM_Mosaico_Utils::editCiviMsgTemplateInMosaico</page_callback>
     <title>Integration with Mosaico</title>
-    <access_arguments>access CiviCRM Mosaico</access_arguments>
+    <access_arguments>edit message templates</access_arguments>
   </item>
   <item>
     <path>civicrm/mosaico/ajax/settemplate</path>
     <page_callback>CRM_Mosaico_Utils::setTemplateinMosaicoCustomTable</page_callback>
     <title>Update Mosaico Template</title>
-    <access_arguments>access CiviCRM Mosaico</access_arguments>
+    <access_arguments>edit message templates</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
Core has permissions to distinguish between users who can (a) send mailings
and (b) edit templates.  Mosaico 1.x added another permission (`access
CiviCRM Mosaico`) for accessing Mosaico, but this required more
configuration.

With this patch, we simplify installation in 2.x by removing the permission
`access CiviCRM Mosaico`.  Instead, we pantomime core's permissions:n

 * You can edit a Mosaico template - if and only if you can edit a core
   template.
 * You can compose a Mosaico mailing - if and only if you can compose a core
   mailing.