### PR TITLE
crmMosaicoIframe - Tune IFRAME alignment (#114, etal)

### DIFF
--- a/ang/crmMosaico/Iframe.js
+++ b/ang/crmMosaico/Iframe.js
@@ -22,6 +22,7 @@
     return function CrmMosaicoIframe(options){
       var cfg = {
         url: CRM.url('civicrm/mosaico/iframe', 'snippet=1'),
+        zIndex: 1000,
         topMargin: 25 // Height of the CiviCRM navbar. Ugh.
       };
       angular.extend(cfg, options);
@@ -40,7 +41,7 @@
       this.render = function render() {
         var height = $(window).height() - cfg.topMargin;
         $iframe = $('<iframe frameborder="0" width="100%">');
-        $iframe.css({'z-index': 100, position: 'fixed', left:0, top: cfg.topMargin, width: '100%', height: height + 'px'});
+        $iframe.css({'z-index': cfg.zIndex, position: 'fixed', left:0, top: cfg.topMargin, width: '100%', height: height + 'px'});
         // 'z-index': 100000000
         iframe = $iframe[0];
         iframe.setAttribute('src', cfg.url);

--- a/ang/crmMosaico/Iframe.js
+++ b/ang/crmMosaico/Iframe.js
@@ -33,13 +33,19 @@
         throw "Error: Save and Close actions are mutually exclusive";
       }
 
+      function onResize() {
+        if ($iframe) $iframe.height($(window).height() - cfg.topMargin);
+      }
+
       this.render = function render() {
+        var height = $(window).height() - cfg.topMargin;
         $iframe = $('<iframe frameborder="0" width="100%">');
-        $iframe.css({'z-index': 100, position: 'fixed', left:0, top: cfg.topMargin, width: '100%', height: '100%'});
+        $iframe.css({'z-index': 100, position: 'fixed', left:0, top: cfg.topMargin, width: '100%', height: height + 'px'});
         // 'z-index': 100000000
         iframe = $iframe[0];
         iframe.setAttribute('src', cfg.url);
         $('body').append($iframe);
+        $(window).on('resize', onResize);
         return this;
       };
 
@@ -91,6 +97,7 @@
 
       this.destroy = function destroy() {
         this.hide();
+        $(window).off('resize', onResize);
         if ($iframe) $iframe.remove();
         iframe = $iframe = null;
         return this;

--- a/ang/crmMosaico/Iframe.js
+++ b/ang/crmMosaico/Iframe.js
@@ -23,7 +23,7 @@
       var cfg = {
         url: CRM.url('civicrm/mosaico/iframe', 'snippet=1'),
         zIndex: 1000,
-        topMargin: 25 // Height of the CiviCRM navbar. Ugh.
+        topMargin: $('#civicrm-menu').length > 0 ? $('#civicrm-menu').height() : 27
       };
       angular.extend(cfg, options);
 

--- a/ang/crmMosaico/MixinCtrl.js
+++ b/ang/crmMosaico/MixinCtrl.js
@@ -59,7 +59,9 @@
           mailing.template_options.mosaicoContent = viewModel.exportJSON();
         }
 
+        var iframeZIndex = 10000;
         crmMosaicoIframe = new CrmMosaicoIframe({
+          zIndex: iframeZIndex,
           model: {
             template: $scope.mosaicoCtrl.getTemplate(mailing).path,
             metadata: mailing.template_options.mosaicoMetadata,
@@ -81,7 +83,10 @@
                 {autoOpen: false, title: ts('Test Mailing')},
                 options
               ));
-              return dialogService.open('crmMosaicoPreviewDialog', '~/crmMosaico/PreviewDialogCtrl.html', model, options);
+              var pr = dialogService.open('crmMosaicoPreviewDialog', '~/crmMosaico/PreviewDialogCtrl.html', model, options);
+              // Ugh, can't find a better way to match up z-indexes of crmMosaicoIframe and dialogService.
+              $timeout(function(){$('.ui-dialog.crm-container').last().zIndex(iframeZIndex + 100);}, 100);
+              return pr;
             }
           }
         });


### PR DESCRIPTION
This fixes three issues with IFRAME alignment:
 * Compute the height dynamically based on the window size to fix the
   weird cutoff a the bottom.
 * Increase the `z-index` to stack on top of the WordPress menu.
 * Set the `top` position dynamically based on height of the menu bar
   to resolve 2-3 pixels of weirdness.