### PR TITLE
Hide `tedc15` base template

### DIFF
--- a/CRM/Mosaico/BAO/MosaicoTemplate.php
+++ b/CRM/Mosaico/BAO/MosaicoTemplate.php
@@ -30,16 +30,16 @@ class CRM_Mosaico_BAO_MosaicoTemplate extends CRM_Mosaico_DAO_MosaicoTemplate {
       $records = array();
       $records[] = array(
         'name' => 'versafix-1',
-        'title' => 'Versafix 1',
+        'title' => 'Versafix',
         'thumbnail' => CRM_Mosaico_Utils::getTemplatesUrl('absolute', 'versafix-1/edres/_full.png'),
         'path' => 'templates/versafix-1/template-versafix-1.html',
       );
-      $records[] = array(
-        'name' => 'tedc15',
-        'title' => 'TEDC 15',
-        'thumbnail' => CRM_Mosaico_Utils::getTemplatesUrl('absolute', 'tedc15/edres/_full.png'),
-        'path' => 'templates/tedc15/template-tedc15.html',
-      );
+      // $records[] = array(
+      //   'name' => 'tedc15',
+      //   'title' => 'TEDC 15',
+      //   'thumbnail' => CRM_Mosaico_Utils::getTemplatesUrl('absolute', 'tedc15/edres/_full.png'),
+      //   'path' => 'templates/tedc15/template-tedc15.html',
+      // );
       Civi::$statics[__CLASS__]['bases'] = $records;
     }
     return Civi::$statics[__CLASS__]['bases'];


### PR DESCRIPTION
Recap:
 * This was discussed a little on Mattermast. No -1's.
 * This reduces the surface area of potential support questions.
 * Easier to hide it now (pre-2.0) than later (post-2.0).
 * The name is pretty opaque.

However, if somebody can make an argument that it does serve a useful
purpose, then we should re-enable it.