### PR TITLE
Mosaico.setting.php - Refine title of `mosaico_layout`

### DIFF
--- a/settings/Mosaico.setting.php
+++ b/settings/Mosaico.setting.php
@@ -15,7 +15,7 @@ return array(
     ),
     'default' => 'auto',
     'add' => '4.7',
-    'title' => 'Editor layout',
+    'title' => 'Mosaico editor layout',
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => NULL,


### PR DESCRIPTION
When browsing the settings via "API Explorer", the parameter "Editor Layout"
isn't very clear.  This changes it to the more precise "Mosaico editor
layout".