### PR TITLE
Mosaico.setting.php - Add file to zip. Cleanup fallout.

### DIFF
--- a/CRM/Mosaico/Upgrader.php
+++ b/CRM/Mosaico/Upgrader.php
@@ -58,8 +58,9 @@ class CRM_Mosaico_Upgrader extends CRM_Mosaico_Upgrader_Base {
   }
 
   /**
-   * One the 2.x-alpha releases was missing the file `Mosaico.setting.php`. If you tried to change the
-   * layout setting while this file was missing, you could have a boinked record in "civicrm_setting".
+   * One of the 2.x-alpha releases was missing the file `Mosaico.setting.php`.
+   * If you installed on Civi v4.6 and tried to change the layout setting while
+   * this file was missing, you could have a boinked record in "civicrm_setting".
    */
   public function upgrade_4701() {
     $this->ctx->log->info('Applying update 4701');

--- a/CRM/Mosaico/Upgrader.php
+++ b/CRM/Mosaico/Upgrader.php
@@ -55,7 +55,19 @@ class CRM_Mosaico_Upgrader extends CRM_Mosaico_Upgrader_Base {
     )  ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci  ;
     ');
     return TRUE;
-  } // */
+  }
+
+  /**
+   * One the 2.x-alpha releases was missing the file `Mosaico.setting.php`. If you tried to change the
+   * layout setting while this file was missing, you could have a boinked record in "civicrm_setting".
+   */
+  public function upgrade_4701() {
+    $this->ctx->log->info('Applying update 4701');
+    if (CRM_Core_DAO::checkFieldExists('civicrm_setting', 'group_name')) {
+      CRM_Core_DAO::executeQuery('UPDATE civicrm_setting SET group_name = "Mosaico Preferences" WHERE name="mosaico_layout"');
+    }
+    return TRUE;
+  }
 
   /**
    * Example: Run an external SQL script.

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -119,7 +119,7 @@ function do_zipfile() {
        ## Get any files in the project root.
        find . -mindepth 1 -maxdepth 1 -type f -o -type d
        ## Get any files in the main subfolders.
-       find CRM/ ang/ api/ bin/ css/ js/ sql/ templates/ xml/ -type f -o -type d
+       find CRM/ ang/ api/ bin/ css/ js/ sql/ settings/ templates/ xml/ -type f -o -type d
        ## Get the distributable files for Mosaico.
        find packages/mosaico/{NOTICE,README,LICENSE,dist,templates}* -type f -o -type d
     } \


### PR DESCRIPTION
If you installed Mosaico 2.x on Civi v4.6 using the zip file, the setting `mosaico_layout` didn't work - it wasn't possible to enable the wizard layout. This fixes it.