### PR TITLE
crmMosaico.css - Workaround for style bug with the help icon in v4.6

### DIFF
--- a/ang/crmMosaico.css
+++ b/ang/crmMosaico.css
@@ -42,3 +42,8 @@
 #bootstrap-theme.crm-mosaico-wizard {
     padding: 0.7em;
 }
+
+/* Evil workaround for buggy 4.6 styling. Remove me when 4.6 dies. */
+#bootstrap-theme.crm-mosaico-page .helpicon {
+    background-color: #42AFCB;
+}


### PR DESCRIPTION
This code should not exist, but I don't have faith in getting fixed upstream
quickly, so here's a workaround.