### PR TITLE
crmMosaicoBlockMailing - Fix loading of "Reply To" field

### DIFF
--- a/ang/crmMosaico/BlockMailing.html
+++ b/ang/crmMosaico/BlockMailing.html
@@ -25,6 +25,7 @@
       <select
           id="inputFrom"
           class="form-control"
+          crm-ui-select="{dropdownAutoWidth : true, allowClear: false}"
           name="fromAddress"
           ng-model="fromPlaceholder.label"
           required>
@@ -37,17 +38,17 @@
 
   <div class="form-group" ng-show="crmMailingConst.enableReplyTo">
     <label for="inputReplyTo" class="control-label">{{ts('Reply-To')}}</label>
-    <div ng-controller="EmailAddrCtrl" crm-mailing-from-address="fromPlaceholder" crm-mailing="mailing">
+    <div ng-controller="EmailAddrCtrl">
       <select
           id="inputReplyTo"
           class="form-control"
+          crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Email address')}"
           name="replyTo"
           ng-change="checkReplyToChange(mailing)"
-          ng-model="mailing.replyto_email">
+          ng-model="mailing.replyto_email"
+      >
         <option value=""></option>
-        <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'"
-                value="{{frm.label}}">{{frm.label}}
-        </option>
+        <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'" value="{{frm.label}}">{{frm.label}}</option>
       </select>
     </div>
   </div>


### PR DESCRIPTION
The "Reply To" field is an optional one that appears if you enable
"Administer => CiviMail => Mailer Settings => Enable Custom Reply-To".  If
you set a "Reply To" value, saved, and returned to the mailing, then this
field was not properly redisplayed.

In the original CiviMail code, this field was based on `crm-ui-select` (aka
`select2`).  However, during Mosaico development, there were styling issues
with `crm-ui-select`+Bootstrap, so we downgraded to plain HTML `select`.
Alas, that seems to have created the bug with "Reply To".

Fortunately, `select2`+Bootstrap now looks better than before. So we can
restore to the original, working implementation.

(Note: `select2`+Bootstrap looks *better* but not *great*.  It could be
improved.  But IMHO that's an issue for the themers.)