### PR TITLE
crmMosaicoBlockMailing - Fix requirement for "Mailing Name"

### DIFF
--- a/ang/crmMosaico/BlockMailing.html
+++ b/ang/crmMosaico/BlockMailing.html
@@ -3,7 +3,7 @@
   <div class="form-group">
     <label for="inputTitle" class="control-label required">{{ts('Mailing Name')}}
       <a crm-ui-help="hs({id: 'name', title: ts('Mailing Name')})"></a></label>
-    <input type="text" class="form-control" id="inputTitle" placeholder="{{ts('Mailing Name')}}" ng-model="mailing.name">
+    <input type="text" class="form-control" id="inputTitle" placeholder="{{ts('Mailing Name')}}" ng-model="mailing.name" required>
   </div>
 
   <div class="form-group" ng-show="crmMailingConst.campaignEnabled">


### PR DESCRIPTION
You must give a "Mailing Name" before submitting a mailing -- and, in
particular, when using the wizard flow, you need to enter a "Mailing Name"
to get through the first step.