### PR TITLE
mosaico_civicrm_navigationMenu - Fix copy-pasted translation domain

### DIFF
--- a/mosaico.php
+++ b/mosaico.php
@@ -135,7 +135,7 @@ function mosaico_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 
 function mosaico_civicrm_navigationMenu(&$params) {
   _mosaico_civix_insert_navigation_menu($params, 'Mailings', array(
-    'label' => ts('Mosaico Templates', array('domain' => 'org.civicrm.styleguide')),
+    'label' => ts('Mosaico Templates', array('domain' => 'uk.co.vedaconsulting.mosaico')),
     'name' => 'mosaico_templates',
     'permission' => 'edit message templates',
     'child' => array(),


### PR DESCRIPTION
This navmenu was based on some code that was copy-pasted from
`org.civicrm.styleguide`, but it wasn't completely adapted, which could lead
to some weird warning messages.