### PR TITLE
crmMosaico.css - Retarget workaround for style bug with the help icon in v4.6

### DIFF
--- a/ang/crmMosaico-4.6.css
+++ b/ang/crmMosaico-4.6.css
@@ -1,0 +1,4 @@
+/* Evil workaround for buggy 4.6 styling. Remove me when 4.6 dies. */
+#bootstrap-theme.crm-mosaico-page .helpicon {
+    background-color: #42AFCB;
+}

--- a/ang/crmMosaico.ang.php
+++ b/ang/crmMosaico.ang.php
@@ -3,7 +3,7 @@
 // in CiviCRM. See also:
 // http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
 
-return array (
+$result = array (
   'js' => 
   array (
     0 => 'ang/crmMosaico.js',
@@ -23,3 +23,9 @@ return array (
     'canDelete' => Civi::service('civi_api_kernel')->runAuthorize('MosaicoTemplate', 'delete', array('version' => 3, 'check_permissions' => 1)),
   ),
 );
+
+if (version_compare(CRM_Utils_System::version(), '4.7', '<')) {
+  $result['css'][]= 'ang/crmMosaico-4.6.css';
+}
+
+return $result;

--- a/ang/crmMosaico.css
+++ b/ang/crmMosaico.css
@@ -42,8 +42,3 @@
 #bootstrap-theme.crm-mosaico-wizard {
     padding: 0.7em;
 }
-
-/* Evil workaround for buggy 4.6 styling. Remove me when 4.6 dies. */
-#bootstrap-theme.crm-mosaico-page .helpicon {
-    background-color: #42AFCB;
-}


### PR DESCRIPTION
This is necessary in 4.6 but mucks up the appearance in 4.7.