### PR TITLE
Reroll patch from #130 for 1.x branch

### DIFF
--- a/CRM/Mosaico/DAO/MessageTemplate.php
+++ b/CRM/Mosaico/DAO/MessageTemplate.php
@@ -188,7 +188,7 @@ class CRM_Mosaico_DAO_MessageTemplate extends CRM_Core_DAO
           'type' => CRM_Utils_Type::T_STRING,
           'title' => ts('name') ,
           'description' => 'name',
-          'maxlength' => 32,
+          'maxlength' => 255,
           'size' => CRM_Utils_Type::MEDIUM,
         ) ,
         'html' => array(

--- a/sql/auto_install.sql
+++ b/sql/auto_install.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS `civicrm_mosaico_msg_template` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `msg_tpl_id` int(10) unsigned NOT NULL,
   `hash_key` varchar(32) NOT NULL,
-  `name` varchar(32) NOT NULL,
+  `name` varchar(255) NOT NULL,
   `html` longtext NOT NULL,
   `metadata` longtext NOT NULL,
   `template` longtext NOT NULL,

--- a/xml/schema/CRM/Mosaico/MessageTemplate.xml
+++ b/xml/schema/CRM/Mosaico/MessageTemplate.xml
@@ -51,7 +51,7 @@
   <field>
     <name>name</name>
     <type>varchar</type>
-    <length>32</length>
+    <length>255</length>
     <comment>name</comment>
     <title>name</title>
   </field>


### PR DESCRIPTION
Lengthen the name column of the civicrm_mosaico_msg_template table from 32 to 255. This commit assumes the schema is changed by hand:

1. I wasn't sure whether the developers are accepting PRs against 1.x
2. I need to confirm how the upgrade_XXXX function should be named. If I numbered it 4600 then anyone upgrading later to 2.x would be OK, but perhaps there are other upgrades?

Cheers!