### PR TITLE
crmMosaicoIframe - Multiple styling fixes (#134)

### DIFF
--- a/ang/crmMosaico.ang.php
+++ b/ang/crmMosaico.ang.php
@@ -21,6 +21,10 @@ $result = array (
   'settings' => 
   array (
     'canDelete' => Civi::service('civi_api_kernel')->runAuthorize('MosaicoTemplate', 'delete', array('version' => 3, 'check_permissions' => 1)),
+    // If there are any navbars that we should try to avoid, include them
+    // in these jQuery selectors.
+    'topNav' => '#civicrm-menu',
+    'leftNav' => '.wp-admin #adminmenu',
   ),
 );
 

--- a/ang/crmMosaico/Iframe.js
+++ b/ang/crmMosaico/Iframe.js
@@ -8,7 +8,7 @@
 
     /**
      * @param Object newOptions
-     *  - topMargin: int (optional)
+     *  - dimensions: function()
      *  - url: string (optional)
      *  - actions: Object
      *    - save: function(ko, viewModel)
@@ -21,7 +21,20 @@
      */
     return function CrmMosaicoIframe(options){
       var cfg = {
-        url: CRM.url('civicrm/mosaico/iframe', 'snippet=1')
+        url: CRM.url('civicrm/mosaico/iframe', 'snippet=1'),
+        dimensions: function resize() {
+          var c = CRM.crmMosaico || {};
+          var top = 0, left = 0, width = $(window).width(), height = $(window).height();
+          if (c.topNav && $(c.topNav).length > 0) {
+            top = $(c.topNav).height();
+            height -= top;
+          }
+          if (c.leftNav && $(c.leftNav).length > 0) {
+            left = $(c.leftNav).width();
+            width -= left;
+          }
+          return {position: 'fixed', left: left + 'px', top: top + 'px', width: width + 'px', height: height + 'px'};
+        }
       };
       angular.extend(cfg, options);
 
@@ -46,22 +59,7 @@
       }
 
       function onResize() {
-        if ($iframe) {
-          var topMargin = 0, leftMargin = 0;
-          if ($('#civicrm-menu').length > 0) {
-            topMargin = $('#civicrm-menu').height();
-          }
-          if ($('.wp-admin #adminmenu').length > 0) {
-            leftMargin = $('.wp-admin #adminmenu').width();
-          }
-          $iframe.css({
-            position: 'fixed',
-            left: leftMargin + 'px',
-            top: topMargin + 'px',
-            width: ($(window).width() - leftMargin) + 'px',
-            height: ($(window).height() - topMargin) + 'px'
-          });
-        }
+        if ($iframe) $iframe.css(cfg.dimensions());
       }
 
       this.render = function render() {

--- a/ang/crmMosaico/Iframe.js
+++ b/ang/crmMosaico/Iframe.js
@@ -46,17 +46,21 @@
       }
 
       var oldOverflow = null;
-      function scrollStart() {
+      function scrollHide() {
         if (oldOverflow === null) {
           oldOverflow = $('body').css('overflow');
+          $(document).on('dialogclose', scrollRefresh); // jQuery dialog bug
         }
         $('body').css('overflow', 'hidden');
       }
-      function scrollStop() {
-        if (oldOverflow === null) return;
-        $('body').css('overflow', oldOverflow);
+      function scrollRestore() {
+        if (oldOverflow !== null) {
+          $(document).off('dialogclose', scrollRefresh); // jQuery dialog bug
+          $('body').css('overflow', oldOverflow);
+        }
         oldOverflow = null;
       }
+      function scrollRefresh() { $('body').css('overflow', 'hidden'); }
 
       function onResize() {
         if ($iframe) $iframe.css(cfg.dimensions());
@@ -112,7 +116,7 @@
       this.hide = function hide() {
         isVisible = false;
         if ($iframe) {
-          scrollStop();
+          scrollRestore();
           $iframe.hide();
         }
         return this;
@@ -121,7 +125,8 @@
       this.show = function show() {
         isVisible = true;
         if ($iframe) {
-          scrollStart();
+          scrollHide();
+          onResize();
           $iframe.show();
         }
         return this;

--- a/ang/crmMosaico/MixinCtrl.js
+++ b/ang/crmMosaico/MixinCtrl.js
@@ -59,9 +59,7 @@
           mailing.template_options.mosaicoContent = viewModel.exportJSON();
         }
 
-        var iframeZIndex = 10000;
         crmMosaicoIframe = new CrmMosaicoIframe({
-          zIndex: iframeZIndex,
           model: {
             template: $scope.mosaicoCtrl.getTemplate(mailing).path,
             metadata: mailing.template_options.mosaicoMetadata,
@@ -84,8 +82,6 @@
                 options
               ));
               var pr = dialogService.open('crmMosaicoPreviewDialog', '~/crmMosaico/PreviewDialogCtrl.html', model, options);
-              // Ugh, can't find a better way to match up z-indexes of crmMosaicoIframe and dialogService.
-              $timeout(function(){$('.ui-dialog.crm-container').last().zIndex(iframeZIndex + 100);}, 100);
               return pr;
             }
           }

--- a/ang/crmMosaico/TemplateItem.html
+++ b/ang/crmMosaico/TemplateItem.html
@@ -1,5 +1,5 @@
 <span class="thumbnail crm-mosaico-template-item">
-  <img alt="{{myOptions.title}}" src="{{myOptions.img}}" style="height: 180px; width: 100%; display: block;" ng-click="fireAction('onItemClick')">
+  <img alt="{{myOptions.title}}" ng-src="{{myOptions.img}}" style="height: 180px; width: 100%; display: block;" ng-click="fireAction('onItemClick')">
     <a style="float: right;" class="btn btn-xs btn-danger-outline glyphicon glyphicon-remove-sign" title="Delete" ng-if="hasAction('ItemDelete')" crm-confirm="{type: 'delete', obj: {title: 'template'}}" on-yes="fireAction('onItemDelete')"></a>
     <a style="float: right;" class="btn btn-xs btn-danger-outline glyphicon glyphicon-remove-sign" title="Reset" ng-if="hasAction('ItemReset')" crm-confirm="{title: ts('Reset'), message: ts('Are you sure you want to reset this?')}" on-yes="fireAction('onItemReset')"></a>
     <a style="float: right;" class="btn btn-xs btn-info-outline glyphicon glyphicon-duplicate" title="Copy" ng-if="hasAction('ItemCopy')" ng-click="fireAction('onItemCopy')"></a>


### PR DESCRIPTION
Specifically:
 * Don't set zIndex. This fixes the select2 drop down (#134).
 * On WordPress sites, avoid collision with navbar. Its zIndex is too high.
 * Turn off the  body-level scroll bar while iframe is open. It's confusing/unnecessary.