### PR TITLE
HW-297: Sets settings when installing Mosaico extension

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -81,11 +81,6 @@ function do_gencode() {
 }
 
 ##############################
-function set_default_settings() {
-  cv api setting.create mosaico_layout=bootstrap-wizard
-}
-
-##############################
 function do_download() {
   if [ ! -d "$EXTROOT/packages" ]; then
     mkdir "$EXTROOT/packages"
@@ -103,7 +98,6 @@ function do_download() {
     fi
     npm install
     grunt build
-    set_default_settings
   popd >> /dev/null
 }
 

--- a/settings/Mosaico.setting.php
+++ b/settings/Mosaico.setting.php
@@ -13,7 +13,7 @@ return array(
     'pseudoconstant' => array(
       'callback' => 'CRM_Mosaico_Utils::getLayoutOptions',
     ),
-    'default' => 'auto',
+    'default' => 'bootstrap-wizard',
     'add' => '4.7',
     'title' => 'Mosaico editor layout',
     'is_domain' => 1,


### PR DESCRIPTION
Set default layout to 'bootstrap-wizard' using Mosaico settings file instead of using cv command