### PR TITLE
Update release date for beta 2

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,7 +14,7 @@
     <url desc="Support">http://vedaconsulting.co.uk</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2016-08-26</releaseDate>
+  <releaseDate>2017-05-11-</releaseDate>
   <version>2.0-beta2</version>
   <develStage>beta</develStage>
   <compatibility>


### PR DESCRIPTION
@deepak-srivastava Thanks for the comment in https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/pull/152. This is weird since we have beta1 at 23-03-2017 but the date in the info file was still in 2016.

I have updated the date, could you retag beta2 so it can rank at the top?

Much appreciated!