### PR TITLE
setup.sh, info.xml - Small housekeeping changes

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -119,7 +119,7 @@ function do_zipfile() {
        ## Get any files in the project root.
        find . -mindepth 1 -maxdepth 1 -type f -o -type d
        ## Get any files in the main subfolders.
-       find CRM/ ang/ api/ bin/ css/ js/ sql/ settings/ templates/ xml/ -type f -o -type d
+       find CRM/ ang/ api/ bin/ css/ js/ sql/ sass/ settings/ templates/ tests/ xml/ -type f -o -type d
        ## Get the distributable files for Mosaico.
        find packages/mosaico/{NOTICE,README,LICENSE,dist,templates}* -type f -o -type d
     } \

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2017-05-11-</releaseDate>
-  <version>2.0-beta2</version>
+  <version>2.0-beta3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
Changes:
 * `info.xml` - Bump to `2.0-beta3`
   * We've published `2.0-beta2`, so the version in `2.x` should be bumped to something higher.
 * `setup.sh` - Include sass/ and tests/ in *.zip
   * There's no real cost of including these in the *.zip file, and it reduces
     confusion where someone downloads the code and can't prepare or apply a
     patch (because their codebase is incomplete).