### PR TITLE
Add nav menu for traditional mailing

### DIFF
--- a/CRM/Mosaico/Upgrader.php
+++ b/CRM/Mosaico/Upgrader.php
@@ -80,6 +80,30 @@ class CRM_Mosaico_Upgrader extends CRM_Mosaico_Upgrader_Base {
   }
 
   /**
+   * Add menu for traditional mailing.
+   */
+  public function upgrade_4703() {
+    $this->ctx->log->info('Applying update 4703');
+    $domainId = CRM_Core_Config::domainID();
+
+    civicrm_api3('Navigation', 'create', array(
+      'sequential' => 1,
+      'domain_id' => $domainId,
+      'url' => "civicrm/a/#/mailing/new/traditional",
+      'permission' => "access CiviMail,create mailings",
+      'label' => "New Mailing (Traditional)",
+      'permission_operator' => "OR",
+      'has_separator' => 0,
+      'is_active' => 1,
+      'parent_id' => "Mailings",
+    ));
+
+    CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+
+    return TRUE;
+  }
+
+  /**
    * Example: Run an external SQL script.
    *
    * @return TRUE on success

--- a/mosaico.php
+++ b/mosaico.php
@@ -144,6 +144,16 @@ function mosaico_civicrm_navigationMenu(&$params) {
     'url' => CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mosaico-template'),
   ));
 
+  _mosaico_civix_insert_navigation_menu($params, 'Mailings', array(
+    'label' => ts('New Mailing (Traditional)', array('domain' => 'uk.co.vedaconsulting.mosaico')),
+    'name' => 'traditional_mailing',
+    'permission' => 'access CiviMail,create mailings',
+    'child' => array(),
+    'operator' => 'OR',
+    'separator' => 0,
+    'url' => CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mailing/new/traditional'),
+  ));
+
   _mosaico_civix_navigationMenu($params);
 }
 


### PR DESCRIPTION
The latest update from this ext does not include the default message template in new mailing created. [Doc here](https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico#usage) mentions we need to append traditional to the url in order to use the default msg_template present in civicrm.

Worth adding a navigation menu which redirects to the old interface as this PR does?
 or is there an external setting/api that present both(default + mosaico) msg_template on the New Mailing Page? 