### PR TITLE
Fix relative image urls in templates (make social icons work properly)

### DIFF
--- a/CRM/Mosaico/UrlFilter.php
+++ b/CRM/Mosaico/UrlFilter.php
@@ -39,13 +39,22 @@ class CRM_Mosaico_UrlFilter extends \Civi\FlexMailer\Listener\BaseListener {
 
     $callback = function ($matches) use ($stdBase, $domainBase) {
       if (preg_match('/^https?:/', $matches[2]) || empty($matches[2])) {
+        // If path is absolute, or empty, return it without processing
         return $matches[0];
       }
 
+      if (preg_match('/^templates\//', $matches['2'])) {
+        // If path is relative, but prefixed with templates directory, make it absolute
+        $templateBase = CRM_Mosaico_Utils::getTemplatesUrl('absolute');
+        return $matches[1] . $templateBase . substr($matches[2], 9) . $matches[3];
+      }
+
       if ($matches[2]{0} === '/') {
+        // If path is is relative to domain root, return with domain prepended.
         return $matches[1] . $domainBase . $matches[2] . $matches[3];
       }
       else {
+        // Return
         return $matches[1] . $stdBase . $matches[2] . $matches[3];
       }
     };

--- a/mosaico.php
+++ b/mosaico.php
@@ -308,6 +308,24 @@ function _mosaico_civicrm_alterMailContent(&$content) {
 }
 
 /**
+ * We need to filter URLs from Mosaico when displaying a mailing in the browser (it's already done for sent mails)
+ * The default template social icons get saved as templates/versafix-1/img/facebook.png etc.
+ * We need absolute URLs for display.
+ *
+ * @param $params
+ * @param $context
+ */
+function mosaico_civicrm_alterMailParams(&$params, $context) {
+  // When sending mail, context = flexmailer
+  if ($context == 'civimail') {
+    $filter = new CRM_Mosaico_UrlFilter();
+    $html = $filter->filterHtml(array($params['html']));
+    $params['html'] = reset($html);
+  }
+}
+
+
+/**
  * Implements hook_civicrm_mailingTemplateTypes().
  *
  * @throws \CRM_Core_Exception

--- a/mosaico.php
+++ b/mosaico.php
@@ -361,9 +361,11 @@ function mosaico_civicrm_alterMailParams(&$params, $context) {
     // Convert mosaico tokens to civicrm
     _mosaico_civicrm_mosaicoToCiviTokens($params['html']);
     // Replace tokens with real values
-    $html = _mosaico_civicrm_replaceTokens($params['html'], TRUE);
-    if ($html) {
-      $params['html'] = $html;
+    if (isset($params['html'])) {
+      $html = _mosaico_civicrm_replaceTokens($params['html'], TRUE);
+      if ($html) {
+        $params['html'] = $html;
+      }
     }
 
     // Now filter URLs to make sure they are all valid

--- a/mosaico.php
+++ b/mosaico.php
@@ -269,6 +269,54 @@ function _mosaico_civicrm_check_dirs(&$messages) {
 }
 
 /**
+ * Mosaico templates have a few of their own tokens which are named differently from
+ * CiviMail tokens. By treating these as aliases, we can get more compatibility between
+ * Civi's delivery system and upstream Mosaico templates.
+ *
+ * @param $content
+ */
+function _mosaico_civicrm_mosaicoToCiviTokens(&$content) {
+  $tokenAliases = array(
+    // '[profile_link]' => 'FIXME',
+    '[show_link]' => '{mailing.viewUrl}',
+    '[unsubscribe_link]' => '{action.unsubscribeUrl}',
+  );
+  $content = str_replace(array_keys($tokenAliases), array_values($tokenAliases), $content);
+}
+
+/**
+ * Replace civimail tokens
+ * FIXME: This has already been run once when displaying an email in browser.
+ *   But there were still mosaico tokens present which didn't get parsed.
+ * This is pretty much a direct copy from CRM_Mailing_Page_View::run
+ */
+function _mosaico_civicrm_replaceTokens($content, $html = TRUE) {
+  $mailingID = CRM_Utils_Request::retrieve('id', 'String', CRM_Core_DAO::$_nullObject, TRUE);
+  $contactID = CRM_Core_Session::getLoggedInContactID();
+
+  $mailing = new CRM_Mailing_BAO_Mailing();
+  $mailing->id = $mailingID;
+
+  if (!$mailing) {
+    return FALSE;
+  }
+
+  if (!$mailing->find(TRUE)) {
+    CRM_Utils_System::permissionDenied();
+    return NULL;
+  }
+
+  $domain = CRM_Core_BAO_Domain::getDomain();
+
+  $tokens = CRM_Utils_Token::getTokens($content);
+  $content = CRM_Utils_Token::replaceSubscribeInviteTokens($content);
+  $content = CRM_Utils_Token::replaceDomainTokens($content, $domain, $html, $tokens);
+  $content = CRM_Utils_Token::replaceMailingTokens($content, $mailing, NULL, $tokens);
+
+  return $content;
+}
+
+/**
  * Convert dyanmic-y image URLs to static-y URLs.
  *
  * This is analogous to alterMailContent, but we only apply to Mosaico mailings.
@@ -278,17 +326,8 @@ function _mosaico_civicrm_check_dirs(&$messages) {
  * @see CRM_Mosaico_MosaicoComposer
  */
 function _mosaico_civicrm_alterMailContent(&$content) {
-
-  // Mosaico templates have a few of their own tokens which are named differently from
-  // CiviMail tokens. By treating these as aliases, we can get more compatibility between
-  // Civi's delivery system and upstream Mosaico templates.
-  $tokenAliases = array(
-    // '[profile_link]' => 'FIXME',
-    '[show_link]' => '{mailing.viewUrl}',
-    '[unsubscribe_link]' => '{action.unsubscribeUrl}',
-  );
-  $content = str_replace(array_keys($tokenAliases), array_values($tokenAliases), $content);
-
+  // Replace mosaico tokens with CiviCRM equivalents.
+  _mosaico_civicrm_mosaicoToCiviTokens($content);
   /**
    * create absolute urls for Mosaico/imagemagick images when sending an email in CiviMail
    * convert string below into just the absolute url with addition of static directory where correctly sized image is stored
@@ -318,6 +357,16 @@ function _mosaico_civicrm_alterMailContent(&$content) {
 function mosaico_civicrm_alterMailParams(&$params, $context) {
   // When sending mail, context = flexmailer
   if ($context == 'civimail') {
+    // In this context we are displaying in browser, does it do anything else too?
+    // Convert mosaico tokens to civicrm
+    _mosaico_civicrm_mosaicoToCiviTokens($params['html']);
+    // Replace tokens with real values
+    $html = _mosaico_civicrm_replaceTokens($params['html'], TRUE);
+    if ($html) {
+      $params['html'] = $html;
+    }
+
+    // Now filter URLs to make sure they are all valid
     $filter = new CRM_Mosaico_UrlFilter();
     $html = $filter->filterHtml(array($params['html']));
     $params['html'] = reset($html);


### PR DESCRIPTION
This should fix all image URLs that are specified as relative to the template directory (eg. img/facebook.png).  When submitted for preview/send they are rewritten to templates/versafix-1/img/facebook.png - this patch rewrites that format to an absolute format.  Should fix #139 and final part of #160.  @JKingsnorth can you verify?