### PR TITLE
Add variable to allow specifying default repo for setup.sh

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -111,8 +111,9 @@ function do_zipfile() {
     exit 1
   fi
 
-  local zipfile="$EXTROOT/build/build.zip"
+  local zipfile="$EXTROOT/build/$EXTKEY.zip"
   [ -f "$zipfile" ] && rm -f "$zipfile"
+  [ ! -d "$EXTROOT/build" ] && mkdir "$EXTROOT/build"
   pushd "$EXTROOT" >> /dev/null
     ## Build a list of files to include.
     ## Put the files into the *.zip, using a $EXTKEY as a prefix.

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -2,6 +2,7 @@
 set -e
 
 DEFAULT_MOSAICO_BRANCH="v0.15-civicrm-2"
+DEFAULT_MOSAICO_REPO="https://github.com/civicrm/mosaico"
 EXTROOT=$(cd `dirname $0`/..; pwd)
 EXTKEY="uk.co.vedaconsulting.mosaico"
 XMLBUILD="$EXTROOT/build/xml/schema"
@@ -86,7 +87,7 @@ function do_download() {
     mkdir "$EXTROOT/packages"
   fi
   if [ ! -d "$EXTROOT/packages/mosaico" ]; then
-    git clone -b "$DEFAULT_MOSAICO_BRANCH" https://github.com/civicrm/mosaico "$EXTROOT/packages/mosaico"
+    git clone -b "$DEFAULT_MOSAICO_BRANCH" "$DEFAULT_MOSAICO_REPO" "$EXTROOT/packages/mosaico"
   fi
   pushd "$EXTROOT/packages/mosaico" >> /dev/null
     local currentBranch=$(basename /$(git symbolic-ref HEAD 2>/dev/null))


### PR DESCRIPTION
I'm maintaining my own repo that's tracking mosaico master here https://github.com/mattwire/mosaico/tree/master-civicrm-1-mjwconsulting

Adding a variable to define the default repo as well as the existing default branch allows easier management of this.