### PR TITLE
Fix Mosaico menu covered by Drupal toolbar

### DIFF
--- a/ang/crmMosaico.ang.php
+++ b/ang/crmMosaico.ang.php
@@ -24,6 +24,7 @@ $result = array (
     // If there are any navbars that we should try to avoid, include them
     // in these jQuery selectors.
     'topNav' => '#civicrm-menu',
+    'drupalNav' => '#toolbar',
     'leftNav' => '.wp-admin #adminmenu',
   ),
 );

--- a/ang/crmMosaico/Iframe.js
+++ b/ang/crmMosaico/Iframe.js
@@ -26,7 +26,11 @@
           var c = CRM.crmMosaico || {};
           var top = 0, left = 0, width = $(window).width(), height = $(window).height();
           if (c.topNav && $(c.topNav).length > 0) {
-            top = $(c.topNav).height();
+            if (c.drupalNav && $(c.drupalNav).length > 0 && $(c.drupalNav).height() > $(c.topNav).height()) {
+              top = $(c.drupalNav).height();
+            } else {
+              top = $(c.topNav).height();
+            }
             height -= top;
           }
           if (c.leftNav && $(c.leftNav).length > 0) {


### PR DESCRIPTION
Problem: in our Drupal site we use the User Shortcuts which stick down below the CiviCRM menu, but this z-fights with the Mosaico menu.

![image](https://user-images.githubusercontent.com/2336581/30832151-4d400e36-a207-11e7-9905-e35d0fff8e45.png)

This PR fixes the issue by checking for the existence of the Drupal toolbar and offsetting the Mosaico iframe by whichever is larger.

![image](https://user-images.githubusercontent.com/2336581/30832240-98af802c-a207-11e7-8bc7-5305785b3126.png)
