### PR TITLE
Images upload and appear in template builder but not displayed in email

### DIFF
--- a/mosaico.php
+++ b/mosaico.php
@@ -299,7 +299,7 @@ function _mosaico_civicrm_alterMailContent(&$content) {
   $mosaico_image_upload_dir = rawurlencode($mosaico_config['BASE_URL'] . $mosaico_config['UPLOADS_URL']);
 
   $content = preg_replace_callback(
-    "/src=\"h.+img\?src=(" . $mosaico_image_upload_dir . ")(.+)&.*\"/U",
+    "/src=\".+img\?src=(" . $mosaico_image_upload_dir . ")(.+)&.*\"/U",
     function($matches){
       return "src=\"" . rawurldecode($matches[1]) . "static/" . rawurldecode($matches[2]) . "\"";
     },


### PR DESCRIPTION
As mentioned in https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/issues/71#issuecomment-328219478, this PR is solving the problem of images visible in template builder but not in every email clients.

Url like "/civicrm/mosaico/img?src=..." were not properly replaced because the regex expect the url to start with a "h".