### PR TITLE
mosaico_civicrm_check - Allow any directory name

### DIFF
--- a/mosaico.php
+++ b/mosaico.php
@@ -222,14 +222,6 @@ function mosaico_civicrm_check(&$messages) {
       $messages[] = new CRM_Utils_Check_Message('mosaico_base_url', ts('BASE_URL seems incorrect - %1. Images when uploaded, may not appear correctly as thumbnails. Make sure "Image Upload URL" is configured correctly with Administer » System Settings » Resouce URLs.', array(1 => $mConfig['BASE_URL'])), ts('Incorrect image upload url'));
     }
   }
-  $extDirName = basename(__DIR__);
-  if ($extDirName != 'uk.co.vedaconsulting.mosaico') {
-    $messages[] = new CRM_Utils_Check_Message(
-      'mosaico_extdirname',
-      ts("We expect extension directory name to be '%1' instead of '%2'. Images and icons may not load correctly.", array(1 => 'uk.co.vedaconsulting.mosaico', 2 => $extDirName)),
-      ts('Installed extension directory name not suitable')
-    );
-  }
 
   _mosaico_civicrm_check_dirs($messages);
 }


### PR DESCRIPTION
Background
----------

For most of my personal builds, I usually checkout extensions using short
names (e.g.  `org.civicrm.flexmailer` => `flexmailer`;
`org.civicrm.volunteer` => `volunteer`; `uk.co.vedaconsulting.mosaico` =>
`mosaico`).  Why?  The prefixes in the full names tend to be repeated
several times, so it's harder to navigate with tab-completion.

Changing the name works because extensions are mobile -- they should never
directly construct their file paths or URLs; instead, they rely on a service
(like `CRM_Core_Resources`) to resolve addresses.  The Mosaico extension
currently does this.

Before
------
If you checkout the repo as `mosaico`, the system status reports an error,
and you're not allowed to proceed.

After
-----
It works.

To test this, I installed with the short directory name and did the following:
 * Manual test:
   * Make a new mailing. Include a block with custom image and include the footer with social icons.
   * Preview in browser. All images look right.
   * Send test mailing. View it in email client. All images look right.
 * Automated test: Run `phpunit4`. All tests pass.