### PR TITLE
Add "Mosaico Settings" under "Administer => CiviMail"

### DIFF
--- a/CRM/Mosaico/Form/MosaicoAdmin.php
+++ b/CRM/Mosaico/Form/MosaicoAdmin.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_Mosaico_ExtensionUtil as E;
+
+/**
+ * Form controller class
+ *
+ * @see https://wiki.civicrm.org/confluence/display/CRMDOC/QuickForm+Reference
+ */
+class CRM_Mosaico_Form_MosaicoAdmin extends CRM_Admin_Form_Setting {
+
+  protected $_settings = array(
+    'mosaico_layout' => 'Mosaico Preferences',
+  );
+
+  /**
+   * Build the form object.
+   */
+  public function buildQuickForm() {
+    parent::buildQuickForm();
+  }
+
+}

--- a/mosaico.php
+++ b/mosaico.php
@@ -154,6 +154,16 @@ function mosaico_civicrm_navigationMenu(&$params) {
     'url' => CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mailing/new/traditional'),
   ));
 
+  _mosaico_civix_insert_navigation_menu($params, 'Administer/CiviMail', array(
+    'label' => ts('Mosaico Settings', array('domain' => 'uk.co.vedaconsulting.mosaico')),
+    'name' => 'mosaico_settings',
+    'permission' => 'administer CiviCRM',
+    'child' => array(),
+    'operator' => 'AND',
+    'separator' => 0,
+    'url' => CRM_Utils_System::url('civicrm/admin/mosaico', 'reset=1', TRUE),
+  ));
+
   _mosaico_civix_navigationMenu($params);
 }
 

--- a/settings/Mosaico.setting.php
+++ b/settings/Mosaico.setting.php
@@ -4,7 +4,7 @@ return array(
     'group_name' => 'Mosaico Preferences',
     'group' => 'mosaico',
     'name' => 'mosaico_layout',
-
+    'quick_form_type' => 'Select',
     'type' => 'String',
     'html_type' => 'Select',
     'html_attributes' => array(

--- a/templates/CRM/Mosaico/Form/MosaicoAdmin.tpl
+++ b/templates/CRM/Mosaico/Form/MosaicoAdmin.tpl
@@ -1,0 +1,17 @@
+{crmScope extensionKey='uk.co.vedaconsulting.mosaico'}
+<div class="crm-block crm-form-block crm-mosaico-form-block">
+  {*<div class="help">*}
+  {*{ts}...{/ts} {docURL page="Debugging for developers" resource="wiki"}*}
+  {*</div>*}
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="top"}</div>
+  <table class="form-layout">
+    <tr class="crm-mosaico-form-block-mosaico_layout">
+      <td class="label">{$form.mosaico_layout.label}</td>
+      <td>{$form.mosaico_layout.html}<br />
+        <span class="description">{ts}How should the CiviMail composition screen look?{/ts}</span>
+      </td>
+    </tr>
+  </table>
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+</div>
+{/crmScope}

--- a/xml/Menu/mosaico.xml
+++ b/xml/Menu/mosaico.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0"?>
 <menu>
   <item>
+    <path>civicrm/admin/mosaico</path>
+    <page_callback>CRM_Mosaico_Form_MosaicoAdmin</page_callback>
+    <title>Mosaico Settings</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
+  <item>
     <path>civicrm/mosaico/iframe</path>
     <page_callback>CRM_Mosaico_Page_EditorIframe</page_callback>
     <title>Integration with Mosaico</title>

--- a/xml/Menu/mosaico.xml
+++ b/xml/Menu/mosaico.xml
@@ -4,6 +4,8 @@
     <path>civicrm/admin/mosaico</path>
     <page_callback>CRM_Mosaico_Form_MosaicoAdmin</page_callback>
     <title>Mosaico Settings</title>
+    <adminGroup>CiviMail</adminGroup>
+    <icon>admin/small/Profile.png</icon>
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
   <item>


### PR DESCRIPTION
Before
------
The settings for the Mosaico extension were previously invisible.  

After
-----
The nav menu includes an item, "Administer => CiviMail => Mosaico Settings",
which displays the Mosaico settings.