### PR TITLE
Mosaico.setting.php - Switch default layout back to single-page

### DIFF
--- a/settings/Mosaico.setting.php
+++ b/settings/Mosaico.setting.php
@@ -13,7 +13,7 @@ return array(
     'pseudoconstant' => array(
       'callback' => 'CRM_Mosaico_Utils::getLayoutOptions',
     ),
-    'default' => 'bootstrap-wizard',
+    'default' => 'auto',
     'add' => '4.7',
     'title' => 'Mosaico editor layout',
     'is_domain' => 1,


### PR DESCRIPTION
## Background

Early mockups for Mosaico 2.x proscribed a BootstrapCSS-based wizard layout. However, during implementation, we had to address these bits incrementally -- e.g. first, incorporating BootstrapCSS; then developing a Bootstrap-based wizard component; etc. This led to an accidental discovery: an intermediate revision had a single-page layout, and it actually felt pretty easy to use. To see if this was just a personal fluke, I showed both layouts to a couple outsiders (non-Civi folks) who had the same reaction.

Unfortunately, that's anecdotal. There's still a strong element of subjectivity (personal taste, organizational context), and it would be more informative to check with a range of users. After the initial discovery, Jamie agreed to include the layout as a variable in some focus-group user testing, but they ultimately abandoned this. (Guess: the timing didn't work out.) Thus, the debate between "single page layout" and "wizard layout"  essentially remained a matter of irresolvable subjectivity.

## Demo Day: About

I now have more meaningful data with which to address the question of default layout.

Each year, there's a conference in Oakland for non-profit activists/technologists/developers. It attracts people from a number of small and mid-size NGOs (mostly in US; some Latin America), and it includes people with a range of experience in CiviCRM, Salesforce, CiviMail, MailChimp, Constant Contact, etal. It's fairly diverse -- some people have deep experience in several tools; some are just evaluators; many are users; others are consultants or developers. All are in the target market for CiviCRM/CiviMail.

As part of the conference, we had a "demo day" exercise. The format was basically this: you get a group of 5-8 people huddled around a computer, and you have 8 minutes to show off a demo.  Then the audience rotates, and a new group of 5-8 people comes in.  There are 5 iterations of this, which means you get 25-40 people in total.

I used the "demo day" to show off a bunch of the Civi improvements -- e.g. Shoreditch's "View Case", e.g. Mosaico's "New Mailing", e.g. the new CiviCase. *All reactions to the new revisions were quite positive, especially from people who had previously used the old screens.* I think we had ~35 people.

Of course, we've also had this open question about layout... and there's no empirical data... and I've been genuinely curious to understand why reactions differ so strongly. Demo Day seemed like a good opportunity to get real feedback from a large group of users. So, after showing the goodies, I used the last 2 minutes to say: "the development team had some debate about one aspect of Mosaico, and we'd like to get your feedback..." Then I'd demo both layouts and ask for reactions/preferences.

This process didn't have the rigor of a real focus group -- eg I didn't have time to take detailed, contemporaneous notes. The questions weren't planned out in advance, and there wasn't time for much follow-up. But I did capture notes within a day, and I tried to reduce biases in the presentation -- changing the order of presentation, avoiding loaded statements/questions, etc.

IMHO, despite these limits, it's the best data we have so far.

## Demo Day: Results

* Generally:
   * I didn't have time to record exact numbers.
   * Users seemed to prefer the single page layout while consultants seemed to prefer the wizard. 
   * The overall tilt was unmistakable. The ratio of single-vs-wizard preferences was probably 2:1 or 3:1.
* Here a few comments which seemed insightful:
   * __Comment from a consultant, paraphrased__: "When supporting a client, I'd want them using the wizard so that they could tell me exactly which step they were on."
  * __Comment from the same consultant, paraphrased__: "But I wouldn't want to use the wizard myself."
  * __Comment from a user, paraphrased__: "I fiddle a lot with the subject and recipients while working on the mailing. The wizard would make that hard."
  * __Comment from a user, paraphrased__: "The single page is different from other email software (MailChimp, Constant Contact), but it looks easier."
* With one group, I did a follow-up question. The original question was something like, "Which layout seems better?"  The group was originally mixed (~2 for wizard and ~4 for single-page), but the follow-up question shifted the emphasis: "What would you prefer to *use yourself*?" And the result became unanimous: they all preferred to *use* the single-page.

## Comments

As a developer or designer sitting at a computer and working with Github+code, the difference between layouts seems a bit arbitrary and ambiguous. However, *the experience of actually showing each screen to a large pool of users* makes it more visceral. The available information indicates that more users will feel satisfied with usability if the "New Mailing" screen defaults to a single-page layout.

This PR changes the default accordingly.