### PR TITLE
Use .outerHeight() rather than .height() on topNav to include padding

### DIFF
--- a/ang/crmMosaico/Iframe.js
+++ b/ang/crmMosaico/Iframe.js
@@ -26,10 +26,10 @@
           var c = CRM.crmMosaico || {};
           var top = 0, left = 0, width = $(window).width(), height = $(window).height();
           if (c.topNav && $(c.topNav).length > 0) {
-            if (c.drupalNav && $(c.drupalNav).length > 0 && $(c.drupalNav).height() > $(c.topNav).height()) {
-              top = $(c.drupalNav).height();
+            if (c.drupalNav && $(c.drupalNav).length > 0 && $(c.drupalNav).outerHeight() > $(c.topNav).outerHeight()) {
+              top = $(c.drupalNav).outerHeight();
             } else {
-              top = $(c.topNav).height();
+              top = $(c.topNav).outerHeight();
             }
             height -= top;
           }


### PR DESCRIPTION
In order to get the iframe position right the way we're dealing with the 'topNav' on Drupal 8, we need to use `.outerHeight()` rather than `.height()` because we need to count the padding too.