### PR TITLE
"Insert Token" Dialog - Adapt size to 50%x66% (#136)

### DIFF
--- a/js/tinymce-plugins/civicrmtoken/plugin.js
+++ b/js/tinymce-plugins/civicrmtoken/plugin.js
@@ -119,8 +119,8 @@ tinymce.PluginManager.add('civicrmtoken', function(editor, pluginUrl) {
     win = editor.windowManager.open({
       title: 'Insert Token',
       autoScroll: true, // Can we move this to the grid?
-      width: 310,
-      height: 300,
+      width: Math.max(400, Math.round(window.innerWidth/2)),
+      height: Math.max(400, Math.round(window.innerHeight*2/3)),
       body: [
         {
           type: 'textbox',


### PR DESCRIPTION
Before
------
When inserting a token, the dialog size is hard-coded to `{w:310,h:300}`.
Issue #136 (@samuelsov @mlutfy) indicates the token dialog is sometimes too small.

After
-----
When inserting a token, the dialog size adapts to `{w:50%,h:66%}` --
with a minimum of 400px in each dimension.

![image](https://user-images.githubusercontent.com/1336047/33144128-ddbba88a-cf70-11e7-96ac-b4e1d024c11f.png)

Comments
--------
It would be ideal if the dialog width adapted to the size of the *content*
(eg to handle long token names), but I don't know how to accomplish that
with `editor.windowManager.open()`. And I think this is an improvement anyway:

 * This patch effectively increases the width to at least 500px in the average case.  (Rough stat: [95%](https://www.w3schools.com/browsers/browsers_display.asp) of laptop/desktop users have a screen width of at least 1024px; at full screen, that's 512px+.)
 * Compared to the hard-coded version, it should scale a bit better to different screens/dpis.

Note: I'm not particularly fixated on the percentage -- eg if folks prefer to go to `{w:66%,h:80%}` then that would be OK.