### PR TITLE
Accept Mosaico-style unsubscribe URLs during validation (#143)

### DIFF
--- a/CRM/Mosaico/MosaicoRequiredTokens.php
+++ b/CRM/Mosaico/MosaicoRequiredTokens.php
@@ -20,8 +20,22 @@ class CRM_Mosaico_MosaicoRequiredTokens extends RequiredTokens {
   }
 
   public function getRequiredTokens() {
-    return Civi::service('civi_flexmailer_required_tokens')
+    $requiredTokens = Civi::service('civi_flexmailer_required_tokens')
       ->getRequiredTokens();
+
+    // Mosaico's templates handle the mailing-address/contact-info
+    // differently than the CiviMail templates -- one of the standard
+    // blocks provides a section where it prompts you to fill in this info.
+    //
+    // Arguably, this makes the `{domain.address}` requirement redundant.
+    // Arguably, the `{domain.address}` approach is better.
+    //
+    // For the moment, it's convenient to go along with the Mosaico-way.
+    // But it's quite patch-welcome to change (eg inject `{domain.address}`
+    // to the default layout, and then enforce the requirement).
+    unset($requiredTokens['domain.address']);
+
+    return $requiredTokens;
   }
 
   public function findMissingTokens($str) {

--- a/CRM/Mosaico/MosaicoRequiredTokens.php
+++ b/CRM/Mosaico/MosaicoRequiredTokens.php
@@ -1,0 +1,33 @@
+<?php
+use Civi\FlexMailer\Listener\RequiredTokens;
+
+use CRM_Mosaico_ExtensionUtil as E;
+
+/**
+ * Class CRM_Mosaico_MosaicoRequiredTokens
+ *
+ * The token format for Mosaico extends the traditional format -- all
+ * traditional tokens (eg "{action.unsubscribeUrl}") are supported, and
+ * a few additional aliases (eg "[unsubscribe_link]") are also
+ * supported.
+ *
+ * When validating required tokens, we should accept the aliases.
+ */
+class CRM_Mosaico_MosaicoRequiredTokens extends RequiredTokens {
+
+  public function __construct() {
+    parent::__construct(array('mosaico'), array());
+  }
+
+  public function getRequiredTokens() {
+    return Civi::service('civi_flexmailer_required_tokens')
+      ->getRequiredTokens();
+  }
+
+  public function findMissingTokens($str) {
+    $content = array('body_unspecified' => $str);
+    _mosaico_civicrm_alterMailContent($content);
+    return parent::findMissingTokens($content['body_unspecified']);
+  }
+
+}

--- a/CRM/Mosaico/Services.php
+++ b/CRM/Mosaico/Services.php
@@ -22,6 +22,7 @@ class CRM_Mosaico_Services {
     }
     $container->setDefinition('mosaico_flexmail_composer', new Definition('CRM_Mosaico_MosaicoComposer'));
     $container->setDefinition('mosaico_flexmail_url_filter', new Definition('CRM_Mosaico_UrlFilter'));
+    $container->setDefinition('mosaico_required_tokens', new Definition('CRM_Mosaico_MosaicoRequiredTokens'));
 
     foreach (self::getListenerSpecs() as $listenerSpec) {
       $container->findDefinition('dispatcher')->addMethodCall('addListenerService', $listenerSpec);
@@ -31,6 +32,7 @@ class CRM_Mosaico_Services {
   protected static function getListenerSpecs() {
     $listenerSpecs = array();
 
+    $listenerSpecs[] = array(\Civi\FlexMailer\Validator::EVENT_CHECK_SENDABLE, array('mosaico_required_tokens', 'onCheckSendable'), FM::WEIGHT_MAIN);
     $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_composer', 'onCompose'), FM::WEIGHT_MAIN);
     $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_url_filter', 'onCompose'), FM::WEIGHT_ALTER - 100);
 

--- a/CRM/Mosaico/Services.php
+++ b/CRM/Mosaico/Services.php
@@ -32,7 +32,10 @@ class CRM_Mosaico_Services {
   protected static function getListenerSpecs() {
     $listenerSpecs = array();
 
-    $listenerSpecs[] = array(\Civi\FlexMailer\Validator::EVENT_CHECK_SENDABLE, array('mosaico_required_tokens', 'onCheckSendable'), FM::WEIGHT_MAIN);
+    if (class_exists('\Civi\FlexMailer\Validator')) {
+      // TODO Simplify by removing conditional. Wait until at least Feb 2018.
+      $listenerSpecs[] = array(\Civi\FlexMailer\Validator::EVENT_CHECK_SENDABLE, array('mosaico_required_tokens', 'onCheckSendable'), FM::WEIGHT_MAIN);
+    }
     $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_composer', 'onCompose'), FM::WEIGHT_MAIN);
     $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_url_filter', 'onCompose'), FM::WEIGHT_ALTER - 100);
 

--- a/mosaico.php
+++ b/mosaico.php
@@ -231,6 +231,24 @@ function mosaico_civicrm_check(&$messages) {
       \Psr\Log\LogLevel::CRITICAL
     );
   }
+  else {
+    $RECOMMENDED_FLEXMAILER = '0.2-alpha5';
+    $fmInfo = CRM_Extension_System::singleton()->getMapper()->keyToInfo('org.civicrm.flexmailer');
+    if (version_compare($fmInfo->version, $RECOMMENDED_FLEXMAILER, '<')) {
+      $messages[] = new CRM_Utils_Check_Message(
+        'mosaico_flexmailer_ver',
+        ts('The extension %1 expects %2 version <code>%3</code> or newer. Found version <code>%4</code>.', array(
+          1 => 'Mosaico',
+          2 => 'FlexMailer',
+          3 => $RECOMMENDED_FLEXMAILER,
+          4 => $fmInfo->version,
+        )),
+        ts('Outdated dependency'),
+        \Psr\Log\LogLevel::WARNING
+      );
+    }
+  }
+
   if (!empty($mConfig['BASE_URL'])) {
     // detect incorrect image upload url. (Note: Since v4.4.4, CRM_Utils_Check_Security has installed index.html placeholder.)
     $handle = curl_init($mConfig['BASE_URL'] . '/index.html');


### PR DESCRIPTION
Before
------
As observed in #143, the default `versafix-1` templates use tokens like
`[unsubscribe_link]` which do not match `{action.unsubscribeUrl}`. Thus,
when you try to submit the mailing, it fails because the token is missing.

After
-----
The `[unsubscribe_link]` is treated as an alias for
`{action.unsubscribeUrl}`. Thus, when you try to submit the mailing,
it accepts that token.

Comment
-------
There's another required token, `{domain.address}`. For the moment,
the patch waives that requirement because Mosaico UX handles that
differently. See comments inlined.

This patch depends on a recent update to Flexmailer: https://github.com/civicrm/org.civicrm.flexmailer/pull/9 . That patch is currently merged.

To fully work, this patch also depends on an open core PR, https://github.com/civicrm/civicrm-core/pull/11316 . However, it is safe to use this patch without 11316 -- the new code is simply inert.