### PR TITLE
Fix display of group listings on newer builds of CiviCRM

### DIFF
--- a/ang/crmMosaico/BlockMailing.html
+++ b/ang/crmMosaico/BlockMailing.html
@@ -83,11 +83,13 @@
                 <select
                     class="form-control"
                     id="inputUnsubscribeGroup"
+                    crm-ui-select="{dropdownAutoWidth : true}"
                     name="baseGroup"
                     ng-model="mailing.recipients.groups.base[0]"
                     ng-required="true"
                 >
-                  <option ng-repeat="grp in crmMailingConst.groupNames | filter:{is_hidden:0} | orderBy:'title'"
+                  <option value=""></option>
+                  <option ng-repeat="grp in groupNames | filter:{is_hidden:0} | orderBy:'title'"
                           value="{{grp.id}}">{{grp.title}}</option>
                 </select>
               </div>

--- a/ang/crmMosaico/BlockMailing.js
+++ b/ang/crmMosaico/BlockMailing.js
@@ -1,5 +1,27 @@
 (function(angular, $, _) {
-  angular.module('crmMosaico').directive('crmMosaicoBlockMailing', function(crmMailingSimpleDirective) {
-    return crmMailingSimpleDirective('crmMosaicoBlockMailing', '~/crmMosaico/BlockMailing.html');
+  angular.module('crmMosaico').directive('crmMosaicoBlockMailing', function($q, crmMetadata, crmUiHelp) {
+    var directiveName = 'crmMosaicoBlockMailing', templateUrl = '~/crmMosaico/BlockMailing.html';
+    return {
+      scope: {
+        crmMailing: '@'
+      },
+      templateUrl: templateUrl,
+      link: function (scope, elm, attr) {
+        // Common elements - like crmMailingSimpleDirective
+        scope.$parent.$watch(attr.crmMailing, function(newValue){
+          scope.mailing = newValue;
+        });
+        scope.crmMailingConst = CRM.crmMailing;
+        scope.ts = CRM.ts(null);
+        scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
+        scope[directiveName] = attr[directiveName] ? scope.$parent.$eval(attr[directiveName]) : {};
+        $q.when(crmMetadata.getFields('Mailing'), function(fields) {
+          scope.mailingFields = fields;
+        });
+
+        // Unique elements
+        scope.groupNames = CRM.crmMailing.testGroupNames || CRM.crmMailing.groupNames;
+      }
+    };
   });
 })(angular, CRM.$, CRM._);

--- a/ang/crmMosaico/BlockPreview.html
+++ b/ang/crmMosaico/BlockPreview.html
@@ -37,7 +37,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
     ui-jq="crmSelect2"
     ui-options="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Select Group')}"
     ng-model="testGroup.gid"
-    ng-options="group.id as group.title for group in crmMailingConst.groupNames|orderBy:'title'"
+    ng-options="group.id as group.title for group in groupNames|orderBy:'title'"
     class="form-control margin-bottom-10 full-width-force">
     <option value=""></option>
   </select>

--- a/ang/crmMosaico/BlockPreview.js
+++ b/ang/crmMosaico/BlockPreview.js
@@ -9,7 +9,7 @@
         scope.$watch(attr.crmMailing, function(newValue) {
           scope.mailing = newValue;
         });
-        scope.crmMailingConst = CRM.crmMailing;
+        scope.groupNames = CRM.crmMailing.testGroupNames || CRM.crmMailing.groupNames;
         scope.ts = CRM.ts(null);
         scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
         scope.testContact = {email: CRM.crmMailing.defaultTestEmail};
@@ -29,7 +29,7 @@
         scope.previewTestGroup = function(e) {
           var $dialog = $(this);
           $dialog.html('<div class="crm-loading-element"></div>').parent().find('button[data-op=yes]').prop('disabled', true);
-          $dialog.dialog('option', 'title', ts('Send to %1', {1: _.pluck(_.where(scope.crmMailingConst.groupNames, {id: scope.testGroup.gid}), 'title')[0]}));
+          $dialog.dialog('option', 'title', ts('Send to %1', {1: _.pluck(_.where(scope.groupNames, {id: scope.testGroup.gid}), 'title')[0]}));
           CRM.api3('contact', 'get', {
             group: scope.testGroup.gid,
             options: {limit: 0},


### PR DESCRIPTION
Upstream CiviMail made some changes to how the list of groups is managed, which breaks Mosaico on newer builds.

Note the use of `CRM.crmMailing.testGroupNames || CRM.crmMailing.groupNames` is intended to provide compatibility with older and newer protocols.

Problem reported by @eileenmcnaughton on Mattermost (`dev-mosaico`). @seamuslee001 noted similar bugs+patches in traditional CiviMail.