### PR TITLE
crmMosaicoTemplateItem - Fix localization bug

### DIFF
--- a/ang/crmMosaico/EditMailingCtrl/mosaico-wizard.html
+++ b/ang/crmMosaico/EditMailingCtrl/mosaico-wizard.html
@@ -12,7 +12,7 @@
           <div class="col-xs-4 col-md-4 crm-mosaico-selected center-block" crm-mosaico-template-item="{state:'selected', title: ts('My Design'), subtitle: mosaicoCtrl.getTemplate(mailing).type, img: mosaicoCtrl.getTemplate(mailing).thumbnail}" on-item-click="mosaicoCtrl.edit(mailing)" on-item-reset="mosaicoCtrl.reset(mailing)"
               ng-show="!!mailing.template_options.mosaicoTemplate"></div>
           <div ng-repeat="template in mosaicoCtrl.templates" ng-show="!mailing.template_options.mosaicoTemplate">
-            <div class="col-xs-4 col-md-3" crm-mosaico-template-item="{state:'select', title: template.title, subtitle: template.type, img: template.thumbnail}" on-item-click="mosaicoCtrl.select(mailing, template)"></div>
+            <div class="col-xs-4 col-md-3" crm-mosaico-template-item="{state:'select', title: template.title, subtitle: (template.isBase ? template.type : ''), img: template.thumbnail}" on-item-click="mosaicoCtrl.select(mailing, template)"></div>
           </div>
         </div>
       </div>

--- a/ang/crmMosaico/EditMailingCtrl/mosaico.html
+++ b/ang/crmMosaico/EditMailingCtrl/mosaico.html
@@ -22,7 +22,7 @@
             <span ng-model="body_html_defined" crm-ui-validate="!!mailing.body_html"></span>
             <div class="col-xs-4 col-md-4 crm-mosaico-selected center-block" crm-mosaico-template-item="{state:'selected', title: ts('My Design'), subtitle: mosaicoCtrl.getTemplate(mailing).type, img: mosaicoCtrl.getTemplate(mailing).thumbnail}" on-item-click="mosaicoCtrl.edit(mailing)" ng-show="!!mailing.template_options.mosaicoTemplate"></div>
             <div ng-repeat="template in mosaicoCtrl.templates" ng-show="!mailing.template_options.mosaicoTemplate">
-              <div class="col-xs-4 col-md-3" crm-mosaico-template-item="{state:'select', title: template.title, subtitle: template.type, img: template.thumbnail}" on-item-click="mosaicoCtrl.select(mailing, template)"></div>
+              <div class="col-xs-4 col-md-3" crm-mosaico-template-item="{state:'select', title: template.title, subtitle: (template.isBase ? template.type : ''), img: template.thumbnail}" on-item-click="mosaicoCtrl.select(mailing, template)"></div>
             </div>
           </div>
         </div>

--- a/ang/crmMosaico/TemplateItem.html
+++ b/ang/crmMosaico/TemplateItem.html
@@ -17,7 +17,7 @@
   <div class="crm-mosaico-template-title-wrapper">
     <p>
       {{myOptions.title}}
-      <small ng-if="myOptions.subtitle && isEmptyTemplate">{{myOptions.subtitle}}</small>
+      <small ng-if="myOptions.subtitle">{{myOptions.subtitle}}</small>
     </p>
   </div>
 </span>

--- a/ang/crmMosaico/TemplateItem.js
+++ b/ang/crmMosaico/TemplateItem.js
@@ -23,19 +23,14 @@
           new: "New"
         };
 
-        $scope.ts = CRM.ts('mosaico');
+        var ts = $scope.ts = CRM.ts('mosaico');
         $scope.mainActionLabel = "";
-        $scope.isEmptyTemplate = false;
 
         $scope.$watch('crmMosaicoTemplateItem', function (newValue) {
           $scope.myOptions = newValue;
           // Template default action label based on current state
           if (newValue.state) {
             $scope.mainActionLabel = mainActionLabels[newValue.state];
-          }
-          // If Template title is 'Empty Template' then update the scope variable
-          if(newValue.title == 'Empty Template') {
-            $scope.isEmptyTemplate = true;
           }
         });
         $scope.hasAction = function hasAction(action) {


### PR DESCRIPTION
Overview
--------
When choosing a template, the subtitle behavior was inconsistent depending on your localization
settings and data.

Before
------
 * In English: The subtitle was displayed for "Empty Template" items, but it
was not displayed for user-generated
 * In other languages: The subtitle was always displayed.

After
-----
 * In all languages: The subtitle is displayed only for "Empty Template" items.

Comment
-------
It feels silly to use the non-l10n test `subtitle == 'Empty Template'` when there's
metadata (`template.isBase`) which portably conveys the same information. This also
makes the `crmMosaicoTemplateItem` a bit thinner.