### PR TITLE
Hyperlinks - Use absolute URL for uploaded+placeholder images

### DIFF
--- a/CRM/Mosaico/Page/Editor.php
+++ b/CRM/Mosaico/Page/Editor.php
@@ -113,7 +113,10 @@ class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
   protected function getUrl($path, $query, $frontend) {
     // This function shouldn't really exist, but it's tiring to set `$htmlize`
     // to false every.single.time we need a URL.
-    return CRM_Utils_System::url($path, $query, FALSE, NULL, FALSE, $frontend);
+    // These URLs should be absolute -- this influences the final URLs
+    // for any uploaded images, and those will need to be absolute to work
+    // correctly in all forms of composition/delivery.
+    return CRM_Utils_System::url($path, $query, TRUE, NULL, FALSE, $frontend);
   }
 
   /**


### PR DESCRIPTION
Mailings are displayed in several scenarios (such as the "New Mailing" test popup; the "New Mailing" test delivery; the main email delivery; and the "View in browser" link). Relative URLs do not translate well across all these scenarios. We want uploaded images to have absolute URLs.

This PR takes some inspiration from #177 -- rather than post-processing the message content to normalize relative URLs, we just generate the content from the get-go with absolute URLs.

I've run through the full procedure of [Manual Tests: Images and Links](https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/blob/2.x/TESTING.md) on my local environment:
 * __Server environment__: PHP v5.6, MySQL v5.7, Apache v2.4, MailCatcher
 * __Codebase__: `dcase` configuration -- Drupal v7.56, CiviCRM `master` (~v4.7.29), FlexMailer v0.2-alpha5. (Note: Also enabled CiviEvent so I could use it for an example URL.)
 * __Web browser__: Firefox 54
 * __Mail client__: MailCatcher web UI

Everything passes, except for a different pre-existing issue. (The `{action.forward}` token does not work with "Preview as HTML" or "View in Browser".)