### PR TITLE
Migrate templates from 1.x to 2.x

### DIFF
--- a/CRM/Mosaico/DAO/MosaicoTemplate.php
+++ b/CRM/Mosaico/DAO/MosaicoTemplate.php
@@ -116,6 +116,12 @@ class CRM_Mosaico_DAO_MosaicoTemplate extends CRM_Core_DAO {
    */
   public $content;
   /**
+   * FK to civicrm_msg_template.
+   *
+   * @var int unsigned
+   */
+  public $msg_tpl_id;
+  /**
    * class constructor
    *
    * @return civicrm_mosaico_template
@@ -123,6 +129,19 @@ class CRM_Mosaico_DAO_MosaicoTemplate extends CRM_Core_DAO {
   function __construct() {
     $this->__table = 'civicrm_mosaico_template';
     parent::__construct();
+  }
+  /**
+   * Returns foreign keys and entity references
+   *
+   * @return array
+   *   [CRM_Core_Reference_Interface]
+   */
+  static function getReferenceColumns() {
+    if (!self::$_links) {
+      self::$_links = static ::createReferenceColumns(__CLASS__);
+      self::$_links[] = new CRM_Core_Reference_Basic(self::getTableName() , 'msg_tpl_id', 'civicrm_msg_template', 'id');
+    }
+    return self::$_links;
   }
   /**
    * Returns all the column names of this table
@@ -144,7 +163,7 @@ class CRM_Mosaico_DAO_MosaicoTemplate extends CRM_Core_DAO {
           'title' => ts('Title') ,
           'description' => 'Title',
           'maxlength' => 255,
-          'size' => CRM_Utils_Type::BIG,
+          'size' => CRM_Utils_Type::HUGE,
         ) ,
         'base' => array(
           'name' => 'base',
@@ -172,6 +191,22 @@ class CRM_Mosaico_DAO_MosaicoTemplate extends CRM_Core_DAO {
           'title' => ts('Content') ,
           'description' => 'Mosaico content (JSON)',
         ) ,
+        'msg_tpl_id' => array(
+          'name' => 'msg_tpl_id',
+          'type' => CRM_Utils_Type::T_INT,
+          'title' => ts('message template ID') ,
+          'description' => 'FK to civicrm_msg_template.',
+          'required' => false,
+          'FKClassName' => 'CRM_Core_DAO_MessageTemplate',
+          'html' => array(
+            'type' => 'Select',
+          ) ,
+          'pseudoconstant' => array(
+            'table' => 'civicrm_msg_template',
+            'keyColumn' => 'id',
+            'labelColumn' => 'msg_title',
+          )
+        ) ,
       );
     }
     return self::$_fields;
@@ -191,6 +226,7 @@ class CRM_Mosaico_DAO_MosaicoTemplate extends CRM_Core_DAO {
         'html' => 'html',
         'metadata' => 'metadata',
         'content' => 'content',
+        'msg_tpl_id' => 'msg_tpl_id',
       );
     }
     return self::$_fieldKeys;

--- a/CRM/Mosaico/Form/Migrate.php
+++ b/CRM/Mosaico/Form/Migrate.php
@@ -1,0 +1,105 @@
+<?php
+
+use CRM_Mosaico_ExtensionUtil as E;
+
+/**
+ * Form controller class
+ *
+ * @see https://wiki.civicrm.org/confluence/display/CRMDOC/QuickForm+Reference
+ */
+class CRM_Mosaico_Form_Migrate extends CRM_Core_Form {
+
+  public function buildQuickForm() {
+    $this->loadTemplateData();
+
+    $migrateComment = E::ts('Are you sure want to copy data from Mosaico 1.x to 2.x?') . '\n' . E::ts('This action cannot be easily undone.');
+    $purgeComment = E::ts('Are you sure want to purge Mosaico 1.x data?') . '\n' . E::ts('This action cannot be undone.');
+
+    $buttons = array();
+    $buttons[] = array(
+      'type' => 'submit',
+      'name' => ts('Copy'),
+      'subName' => 'migrate',
+      'isDefault' => TRUE,
+      'icon' => 'fa-copy',
+      'js' => array('onclick' => 'return confirm(\'' . $migrateComment . '\');'),
+    );
+    $buttons[] = array(
+      'type' => 'submit',
+      'name' => ts('Purge'),
+      'subName' => 'purge',
+      'icon' => 'fa-trash',
+      'isDefault' => FALSE,
+      'js' => array('onclick' => 'return confirm(\'' . $purgeComment . '\');'),
+    );
+    $this->addButtons($buttons);
+
+    // export form elements
+    $this->assign('elementNames', $this->getRenderableElementNames());
+    parent::buildQuickForm();
+  }
+
+  public function postProcess() {
+    $values = $this->exportValues();
+    if (!empty($values['_qf_Migrate_submit_migrate'])) {
+      $apiResult = civicrm_api3('Job', 'mosaico_migrate', array(
+        'check_permissions' => 1,
+      ));
+      CRM_Core_Session::setStatus(E::ts('Copied %1 templates from Mosaico 1.x to 2.x.', array(
+        1 => $apiResult['count'],
+      )), '', 'success', array(
+        'expires' => 0,
+      ));
+    }
+    elseif (!empty($values['_qf_Migrate_submit_purge'])) {
+      civicrm_api3('Job', 'mosaico_purge', array(
+        'check_permissions' => 1,
+      ));
+      CRM_Core_Session::setStatus(E::ts('Purged invisible Mosaico 1.x data.', array()), '', 'success', array(
+        'expires' => 0,
+      ));
+    }
+    else {
+      CRM_Core_Session::setStatus(E::ts('Unrecognized action'));
+    }
+
+    $this->loadTemplateData();
+    parent::postProcess();
+  }
+
+  /**
+   * Get the fields/elements defined in this form.
+   *
+   * @return array (string)
+   */
+  public function getRenderableElementNames() {
+    // The _elements list includes some items which should not be
+    // auto-rendered in the loop -- such as "qfKey" and "buttons".  These
+    // items don't have labels.  We'll identify renderable by filtering on
+    // the 'label'.
+    $elementNames = array();
+    foreach ($this->_elements as $element) {
+      /** @var HTML_QuickForm_Element $element */
+      $label = $element->getLabel();
+      if (!empty($label)) {
+        $elementNames[] = $element->getName();
+      }
+    }
+    return $elementNames;
+  }
+
+  protected function loadTemplateData() {
+    $oldTemplates = CRM_Core_DAO::executeQuery('SELECT id, name, msg_tpl_id FROM civicrm_mosaico_msg_template')
+      ->fetchAll();
+    $newTemplates = CRM_Core_DAO::executeQuery('SELECT id, title, msg_tpl_id FROM civicrm_mosaico_template')
+      ->fetchAll();
+    $this->assign('oldTemplates', $oldTemplates);
+    $this->assign('newTemplates', $newTemplates);
+
+    $msgTplIds = array_filter(CRM_Utils_Array::collect('msg_tpl_id', $newTemplates), 'is_numeric');
+    sort($msgTplIds);
+    $uniqueIds = array_unique($msgTplIds);
+    $this->assign('msgTplWarning', count($msgTplIds) > count($uniqueIds));
+  }
+
+}

--- a/CRM/Mosaico/Upgrader.php
+++ b/CRM/Mosaico/Upgrader.php
@@ -104,6 +104,27 @@ class CRM_Mosaico_Upgrader extends CRM_Mosaico_Upgrader_Base {
   }
 
   /**
+   * Add menu for traditional mailing.
+   */
+  public function upgrade_4704() {
+    $this->ctx->log->info('Applying update 4704');
+
+    CRM_Core_DAO::executeQuery('
+      ALTER TABLE civicrm_mosaico_template
+      ADD COLUMN `msg_tpl_id` int unsigned NULL COMMENT \'FK to civicrm_msg_template.\'
+    ');
+
+    CRM_Core_DAO::executeQuery('
+      ALTER TABLE civicrm_mosaico_template
+      ADD CONSTRAINT FK_civicrm_mosaico_template_msg_tpl_id
+      FOREIGN KEY (`msg_tpl_id`) REFERENCES `civicrm_msg_template`(`id`)
+      ON DELETE SET NULL
+    ');
+
+    return TRUE;
+  }
+
+  /**
    * Example: Run an external SQL script.
    *
    * @return TRUE on success

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,6 +13,7 @@ verify that the Mosaico data can be read and written when installed on a
 CiviCRM site.
 
 ```
+phpunit4 --group headless
 phpunit4 --group e2e
 ```
 

--- a/api/v3/Job/MosaicoMigrate.php
+++ b/api/v3/Job/MosaicoMigrate.php
@@ -1,0 +1,58 @@
+<?php
+use CRM_Mosaico_ExtensionUtil as E;
+
+/**
+ * Job.mosaico_migrate API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_job_mosaico_migrate_spec(&$spec) {
+}
+
+/**
+ * Job.mosaico_migrate API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ * @throws API_Exception
+ */
+function civicrm_api3_job_mosaico_migrate($params) {
+  $newTpls = array();
+  $dao = new CRM_Mosaico_DAO_MessageTemplate();
+  $dao->find();
+  while ($dao->fetch()) {
+    $metadata = json_decode($dao->metadata, TRUE);
+
+    $newTpl = array();
+    $newTpl['title'] = $dao->name;
+    $newTpl['html'] = $dao->html;
+    $newTpl['metadata'] = $dao->metadata;
+    $newTpl['content'] = $dao->template;
+    $newTpl['msg_tpl_id'] = $dao->msg_tpl_id;
+
+    if ($metadata['template']) {
+      if (preg_match(';packages/mosaico/templates/(.*)/.*html;', $metadata['template'], $matches)) {
+        $newTpl['base'] = $matches[1];
+      }
+    }
+
+    if (empty($newTpl['base'])) {
+      throw new API_Exception("Migration could not be performed. Template #{$dao->id} has unrecognized base template ({$metadata['template']}).", /*errorCode*/ 1234);
+    }
+
+    $newTpls[] = $newTpl;
+  }
+
+  $results = array();
+  foreach ($newTpls as $newTpl) {
+    $result = civicrm_api3('MosaicoTemplate', 'create', $newTpl);
+    $results[$result['id']] = $result['values'][$result['id']];
+  }
+
+  return civicrm_api3_create_success($results, $params, 'Job', 'mosaico_migrate');
+}

--- a/api/v3/Job/MosaicoPurge.php
+++ b/api/v3/Job/MosaicoPurge.php
@@ -1,0 +1,27 @@
+<?php
+use CRM_Mosaico_ExtensionUtil as E;
+
+/**
+ * Job.mosaico_purge API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_job_mosaico_purge_spec(&$spec) {
+}
+
+/**
+ * Job.mosaico_purge API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ * @throws API_Exception
+ */
+function civicrm_api3_job_mosaico_purge($params) {
+  CRM_Core_DAO::executeQuery('DELETE FROM civicrm_mosaico_msg_template');
+  return civicrm_api3_create_success(array(), $params, 'Job', 'mosaico_purge');
+}

--- a/mosaico.php
+++ b/mosaico.php
@@ -260,6 +260,19 @@ function mosaico_civicrm_check(&$messages) {
     }
   }
 
+  $oldTplCount = CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_mosaico_msg_template');
+  if ($oldTplCount > 0) {
+    $messages[] = new CRM_Utils_Check_Message(
+      'mosaico_migrate_1x',
+      ts('Found %1 template(s) from CiviCRM-Mosaico v1.x. Use the <a href="%2">Migration Assistant</a> to load them in v2.x.', array(
+        1 => $oldTplCount,
+        2 => CRM_Utils_System::url('civicrm/admin/mosaico/migrate', 'reset=1'),
+      )),
+      ts('Mosaico: Migrate templates (1.x => 2.x)'),
+      \Psr\Log\LogLevel::WARNING
+    );
+  }
+
   _mosaico_civicrm_check_dirs($messages);
 }
 

--- a/mosaico.php
+++ b/mosaico.php
@@ -357,6 +357,12 @@ function _mosaico_civicrm_alterMailContent(&$content) {
 function mosaico_civicrm_mailingTemplateTypes(&$types) {
   $messages = array();
   mosaico_civicrm_check($messages);
+  $IGNORE_LIST = array('mosaico_migrate_1x');
+  foreach (array_keys($messages) as $key) {
+    if (in_array($messages[$key]->getName(), $IGNORE_LIST)) {
+      unset($messages[$key]);
+    }
+  }
 
   // v4.6 compat
   require_once 'CRM/Mosaico/Utils.php';

--- a/sql/auto_install.sql
+++ b/sql/auto_install.sql
@@ -10,12 +10,14 @@ CREATE TABLE IF NOT EXISTS `civicrm_mosaico_msg_template` (
   CONSTRAINT `FK_civicrm_mosaico_msg_template_msg_tpl_id` FOREIGN KEY (`msg_tpl_id`) REFERENCES `civicrm_msg_template` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
-CREATE TABLE `civicrm_mosaico_template` (
+CREATE TABLE IF NOT EXISTS `civicrm_mosaico_template` (
   `id` int unsigned NOT NULL AUTO_INCREMENT  COMMENT 'Unique Template ID',
   `title` varchar(255)    COMMENT 'Title',
   `base` varchar(64)    COMMENT 'Name of the Mosaico base template (e.g. versafix-1)',
   `html` longtext    COMMENT 'Fully renderd HTML',
   `metadata` longtext    COMMENT 'Mosaico metadata (JSON)',
   `content` longtext    COMMENT 'Mosaico content (JSON)' ,
-   PRIMARY KEY ( `id` )
+  `msg_tpl_id` int unsigned NULL COMMENT 'FK to civicrm_msg_template.',
+   PRIMARY KEY ( `id` ),
+   CONSTRAINT FK_civicrm_mosaico_template_msg_tpl_id FOREIGN KEY (`msg_tpl_id`) REFERENCES `civicrm_msg_template`(`id`) ON DELETE SET NULL
 )  ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci  ;

--- a/templates/CRM/Mosaico/Form/Migrate.tpl
+++ b/templates/CRM/Mosaico/Form/Migrate.tpl
@@ -1,0 +1,106 @@
+{crmScope extensionKey='uk.co.vedaconsulting.mosaico'}
+
+{if !$oldTemplates}
+  <div class="help">
+    <p>
+      {ts}Your system appears to be current. There are no templates to migrate.{/ts}
+    </p>
+  </div>
+{/if}
+
+{if $oldTemplates}
+<h1>{ts}Introduction{/ts}</h1>
+<p class="">
+  {ts}In CiviCRM-Mosaico v1.x, the Mosaico editor integrates <strong>indirectly</strong> with CiviMail. Each Mosaico template is mapped to a CiviCRM <em>Message Template</em> (which may be loaded into CiviMail).{/ts}
+  {ts}This allows the template to be used in many different ways, but the indirection leads to some user-experiences quirks.{/ts}
+</p>
+<p class="">
+  {ts}In CiviCRM-Mosaico v2.x, the Mosaico editor integrates <strong>directly</strong> with CiviMail.{/ts}
+  {ts}This provides a more consistent user-experience, but it changes the data-structure, and it sacrifices some flexibility.{/ts}
+</p>
+<p class="">
+  {ts}This migration assistant will help you move templates from v1.x in v2.x.{/ts}
+</p>
+
+<p class="help">
+  {ts 1="https://github.com/civicrm/org.civicrm.mosaicomsgtpl"}<strong>Tip</strong>: If you would still like to use <em>Message Templates</em> in v2.x, please visit <a href="%1" target="_blank">%1</a>.{/ts}
+</p>
+{/if}
+
+<br/>
+<h1>{ts}Template Summary{/ts}</h1>
+
+<h3>{ts}Mosaico 1.x Templates{/ts}</h3>
+{if $oldTemplates}
+  <table>
+    <thead>
+    <tr>
+      <th>{ts}Name{/ts}</th>
+      <th>{ts}1.x ID{/ts}</th>
+      <th>{ts}Message Template ID{/ts}</th>
+    </tr>
+    </thead>
+    <tbody>
+    {foreach from=$oldTemplates item=tpl}
+      <tr>
+        <td>{$tpl.name}</td>
+        <td>{$tpl.id}</td>
+        <td>{$tpl.msg_tpl_id}</td>
+      </tr>
+    {/foreach}
+    </tbody>
+  </table>
+{else}
+  <p>{ts}No templates found{/ts}</p>
+{/if}
+
+{capture assign=tplBrowseUrl}{crmURL p='civicrm/a/#/mosaico-template'}{/capture}
+<h3>{ts}Mosaico 2.x Templates{/ts} (<a href="{$tplBrowseUrl}" target="_blank">{ts}Manage{/ts}</a>)</h3>
+{if $newTemplates}
+  <table>
+    <thead>
+    <tr>
+      <th>{ts}Name{/ts}</th>
+      <th>{ts}2.x ID{/ts}</th>
+      <th>{ts}Message Template ID{/ts}</th>
+    </tr>
+    </thead>
+    <tbody>
+    {foreach from=$newTemplates item=tpl}
+      <tr>
+        <td>{$tpl.title}</td>
+        <td>{$tpl.id}</td>
+        <td>{$tpl.msg_tpl_id}</td>
+      </tr>
+    {/foreach}
+    </tbody>
+  </table>
+{else}
+  <p>{ts}No templates found{/ts}</p>
+{/if}
+
+{if $msgTplWarning}
+  <p>
+    {ts}<strong>WARNING</strong>: Some <em>Message Templates</em> are mapped to multiple <em>Mosaico Templates</em>!{/ts}
+    {ts}If you setup synchronization, this could cause problems.{/ts}
+  </p>
+{/if}
+
+{if $oldTemplates}
+  <br/>
+  <h1>{ts}Suggested Process{/ts}</h1>
+
+  <ol>
+    <li>{ts}<u>Copy</u>: Use this Migration Assistant to <em>copy</em> every template from Mosaico v1.x to v2.x. This will let you continue using your old templates.{/ts}</li>
+    <li>{ts}<u>Evaluate</u>: Use the new system for a while. If you don't like it, you can downgrade.{/ts}</li>
+    <li>{ts}<u>Purge</u>: Use this Migration Assistant to <em>purge</em> all the old templates from v1.x. This removes any in-app notices about the migration process.{/ts}</li>
+  </ol>
+{/if}
+
+{if $oldTemplates}
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
+{/if}
+
+{/crmScope}

--- a/templates/CRM/Mosaico/Form/Migrate.tpl
+++ b/templates/CRM/Mosaico/Form/Migrate.tpl
@@ -22,9 +22,9 @@
   {ts}This migration assistant will help you move templates from v1.x in v2.x.{/ts}
 </p>
 
-<p class="help">
-  {ts 1="https://github.com/civicrm/org.civicrm.mosaicomsgtpl"}<strong>Tip</strong>: If you would still like to use <em>Message Templates</em> in v2.x, please visit <a href="%1" target="_blank">%1</a>.{/ts}
-</p>
+{*<p class="help">*}
+  {*{ts 1="https://github.com/civicrm/org.civicrm.mosaicomsgtpl"}<strong>Tip</strong>: If you would still like to use <em>Message Templates</em> in v2.x, please visit <a href="%1" target="_blank">%1</a>.{/ts}*}
+{*</p>*}
 {/if}
 
 <br/>

--- a/templates/CRM/Mosaico/Form/Migrate.tpl
+++ b/templates/CRM/Mosaico/Form/Migrate.tpl
@@ -22,9 +22,9 @@
   {ts}This migration assistant will help you move templates from v1.x in v2.x.{/ts}
 </p>
 
-{*<p class="help">*}
-  {*{ts 1="https://github.com/civicrm/org.civicrm.mosaicomsgtpl"}<strong>Tip</strong>: If you would still like to use <em>Message Templates</em> in v2.x, please visit <a href="%1" target="_blank">%1</a>.{/ts}*}
-{*</p>*}
+<p class="help">
+  {ts 1="https://github.com/civicrm/org.civicrm.mosaicomsgtpl"}<strong>Tip</strong>: If you would still like to use <em>Message Templates</em> in v2.x, please visit <a href="%1" target="_blank">%1</a>.{/ts}
+</p>
 {/if}
 
 <br/>

--- a/tests/phpunit/api/v3/Job/MosaicoMigrateTest.php
+++ b/tests/phpunit/api/v3/Job/MosaicoMigrateTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Job.MosaicoMigrate API Test Case
+ * This is a generic test class implemented with PHPUnit.
+ * @group headless
+ */
+class api_v3_Job_MosaicoMigrateTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  /**
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   * See: https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
+   */
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * The setup() method is executed before the test is executed (optional).
+   */
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * The tearDown() method is executed after the test was executed (optional)
+   * This can be used for cleanup.
+   */
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Simple example test case.
+   *
+   * Note how the function name begins with the word "test".
+   */
+  public function testMigrate() {
+    $this->createExampleLegacyTemplate();
+    $this->assertEquals(1, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_mosaico_msg_template'));
+    $this->assertEquals(0, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_mosaico_template'));
+
+    $result = civicrm_api3('Job', 'mosaico_migrate', array());
+    $this->assertEquals(1, count($result['values']));
+    foreach ($result['values'] as $k => $v) {
+      $this->assertEquals($k, $v['id']);
+      $this->assertEquals('versafix-1', $v['base']);
+    }
+    $this->assertEquals(1, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_mosaico_msg_template'));
+    $this->assertEquals(1, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_mosaico_template'));
+
+    $tpl = civicrm_api3('MosaicoTemplate', 'getsingle', array());
+    $this->assertEquals('The Name', $tpl['title']);
+    $this->assertEquals('versafix-1', $tpl['base']);
+
+    $result = civicrm_api3('Job', 'mosaico_purge', array());
+    $this->assertEquals(0, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_mosaico_msg_template'));
+    $this->assertEquals(1, CRM_Core_DAO::singleValueQuery('SELECT count(*) FROM civicrm_mosaico_template'));
+  }
+
+  protected function createExampleLegacyTemplate() {
+    $msgTpl = civicrm_api3('MessageTemplate', 'create', array(
+      'msg_title' => 'The Title',
+      'msg_subject' => 'The Subject',
+      'msg_html' => '<p>Placeholder</p>',
+    ));
+
+    CRM_Core_DAO::executeQuery('
+      INSERT INTO civicrm_mosaico_msg_template (msg_tpl_id, hash_key, name, html, metadata, template)
+      VALUES (%1, "1234abcd", "The Name", "<p>The markup</p>", %2, %3)
+    ', array(
+      1 => array($msgTpl['id'], 'Positive'),
+      2 => array(
+        '{"template":"http://dcase.l/sites/all/modules/civicrm/ext/mosaico/packages/mosaico/templates/versafix-1/template-versafix-1.html","name":"No name","created":1512016950525,"editorversion":"0.15.0","templateversion":"1.0.5","changed":1512016954547}',
+        'String',
+      ),
+      3 => array(json_encode(array('type' => 'template')), 'String'),
+    ));
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -3,7 +3,7 @@
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
 define('CIVICRM_CONTAINER_CACHE', 'never');
-eval(cv('php:boot --level=full', 'phpcode'));
+eval(cv('php:boot --level=classloader', 'phpcode'));
 
 /**
  * Call the "cv" command.

--- a/xml/Menu/mosaico.xml
+++ b/xml/Menu/mosaico.xml
@@ -9,6 +9,12 @@
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
   <item>
+    <path>civicrm/admin/mosaico/migrate</path>
+    <page_callback>CRM_Mosaico_Form_Migrate</page_callback>
+    <title>Mosaico Migration Assistant</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
+  <item>
     <path>civicrm/mosaico/iframe</path>
     <page_callback>CRM_Mosaico_Page_EditorIframe</page_callback>
     <title>Integration with Mosaico</title>

--- a/xml/schema/CRM/Mosaico/MosaicoTemplate.xml
+++ b/xml/schema/CRM/Mosaico/MosaicoTemplate.xml
@@ -54,4 +54,27 @@
     <type>longtext</type>
     <comment>Mosaico content (JSON)</comment>
   </field>
+
+  <field>
+    <name>msg_tpl_id</name>
+    <type>int unsigned</type>
+    <title>message template ID</title>
+    <required>false</required>
+    <comment>FK to civicrm_msg_template.</comment>
+    <pseudoconstant>
+      <table>civicrm_msg_template</table>
+      <keyColumn>id</keyColumn>
+      <labelColumn>msg_title</labelColumn>
+    </pseudoconstant>
+    <html>
+      <type>Select</type>
+    </html>
+  </field>
+  <foreignKey>
+    <name>msg_tpl_id</name>
+    <table>civicrm_msg_template</table>
+    <key>id</key>
+    <onDelete>SET NULL</onDelete>
+  </foreignKey>
+
 </table>


### PR DESCRIPTION
Overview
---------
This PR adds a migration assistant to help folks move templates from v1.x to v2.x

It also updates the schema so that we can preserve the data about msg_tpl_id mappings. The data isn't used within this PR -- but it's likely to be used by an experimental extension.

The "migration assistant" approach is a little less automated than using `updated_NNNN()`, but it allows us to cope more transparently with the oddball scenarios that evaluators are likely to have created when juggling v1.x and v2.x.

Before
-------
Templates from v1.x and v2.x live in separate tables. 

When you upgrade to 2.x, your old templates are no longer available for editing via Mosaico.

After
-----
If you have templates from v1.x, a status alert is displayed:

![screen shot 2017-11-29 at 11 49 53 pm](https://user-images.githubusercontent.com/1336047/33419613-074a1b7e-d560-11e7-888f-14b7f8f9ae8d.png)

Which directs you to a migration assistant:

![screen shot 2017-11-29 at 11 49 36 pm](https://user-images.githubusercontent.com/1336047/33419612-07317a74-d560-11e7-9529-9cf5a7cea0cc.png)

The migration tasks are also available as APIs (`Job.mosaico_migrate` and `Job.mosaico_purge`).