### PR TITLE
Fix small HTML validation errors

### DIFF
--- a/ang/crmMosaico/EditMailingCtrl/mosaico-wizard.html
+++ b/ang/crmMosaico/EditMailingCtrl/mosaico-wizard.html
@@ -24,7 +24,7 @@
           {{ts('Advanced Mailing Options')}}
         </button>
         </div>
-        <div crm-mosaico-block-schedule crm-mailing="mailing" />
+        <div crm-mosaico-block-schedule crm-mailing="mailing"></div>
       </div>
 
       <button class="btn btn-secondary-outline" crmb-wizard-button-position="left" ng-click="crmbWizardCtrl.previous()" ng-show="!crmbWizardCtrl.$first()">

--- a/ang/crmMosaico/EditMailingCtrl/mosaico.html
+++ b/ang/crmMosaico/EditMailingCtrl/mosaico.html
@@ -37,7 +37,7 @@
           <!--{{ts('Advanced Mailing Options')}}-->
           <!--</button>-->
           <!--</div>-->
-          <div crm-mosaico-block-schedule crm-mailing="mailing" />
+          <div crm-mosaico-block-schedule crm-mailing="mailing"></div>
         </div>
       </div>
 

--- a/ang/crmMosaico/PreviewDialogCtrl.html
+++ b/ang/crmMosaico/PreviewDialogCtrl.html
@@ -1,5 +1,5 @@
 <div id="bootstrap-theme">
   <div ng-controller="CrmMosaicoPreviewDialogCtrl" class="crm-mosaico-page">
-    <div crm-mosaico-block-preview crm-mailing="model.mailing" on-preview="previewMailing(model.mailing, preview.mode)" on-send="sendTest(model.mailing, model.attachments, preview.recipient)" />
+    <div crm-mosaico-block-preview crm-mailing="model.mailing" on-preview="previewMailing(model.mailing, preview.mode)" on-send="sendTest(model.mailing, model.attachments, preview.recipient)"></div>
   </div>
 </div>


### PR DESCRIPTION
Browsers accept this markup, but the server-side parser (`phpQuery`)
don't support it consistently, so it's better to be safe.