### PR TITLE
Fix errors when smarty is enabled in settings

### DIFF
--- a/mosaico.php
+++ b/mosaico.php
@@ -412,3 +412,19 @@ function mosaico_civicrm_container(\Symfony\Component\DependencyInjection\Contai
   require_once 'CRM/Mosaico/Services.php';
   CRM_Mosaico_Services::registerServices($container);
 }
+
+/**
+ * Implements hook_civicrm_alterMailContent().
+ */
+function mosaico_civicrm_alterMailContent(&$content) {
+  //Smarty enabled in setting file errors with the style css present
+  //in the mosaico templates. This code encloses <style> with {literal},
+  //which ensures the parsing of mail content is done correctly.
+  if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY == 1 && !empty($content['html']) && strpos($content['html'], '{literal}') === FALSE) {
+    $literals = array(
+      '<style type="text/css">' => '<style type="text/css">{literal}',
+      '</style>' => '{/literal}</style>',
+    );
+    $content['html'] = str_ireplace(array_keys($literals), array_values($literals), $content['html']);
+  }
+}


### PR DESCRIPTION
Smarty error is shown on viewing a mailing which includes css in html. This only gets triggered when `CIVICRM_MAIL_SMARTY ` is enabled in settings. To reproduce -

- Create a mailing using versafix-1 template.
- Submit it and view the mailing page.

![image](https://user-images.githubusercontent.com/5929648/39851563-283a2e06-5435-11e8-8c99-0c9730c206a4.png)

---------
Issue raised in https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/issues/233