### PR TITLE
CIVICRM-886: Update injected parameters for crmMosaicoBlockMailing

### DIFF
--- a/ang/crmMosaico/BlockMailing.js
+++ b/ang/crmMosaico/BlockMailing.js
@@ -1,5 +1,5 @@
 (function(angular, $, _) {
-  angular.module('crmMosaico').directive('crmMosaicoBlockMailing', function($q, crmMetadata, crmUiHelp) {
+  angular.module('crmMosaico').directive('crmMosaicoBlockMailing', function(crmMailingSimpleDirective) {
     return crmMailingSimpleDirective('crmMosaicoBlockMailing', '~/crmMosaico/BlockMailing.html');
   });
 })(angular, CRM.$, CRM._);


### PR DESCRIPTION
#249 introducted a regression where the directive definition crmMosaicoBlockMailing does not have crmMailingSimpleDirective injected, preventing the mailing UI from loading at all in our testing.

This adds it back into the parameters, allowing the interface to load again.