### PR TITLE
Dependencies - Fix crash on Shoreditch; improve metadata

### DIFF
--- a/ang/crmMosaico.ang.php
+++ b/ang/crmMosaico.ang.php
@@ -4,6 +4,7 @@
 // http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
 
 $result = array (
+  'requires' => array('crmUi', 'crmUtil', 'ngRoute', 'crmMailing'),
   'js' =>
   array (
     0 => 'ang/crmMosaico.js',

--- a/ang/crmMosaico.js
+++ b/ang/crmMosaico.js
@@ -1,6 +1,4 @@
 (function(angular, $, _) {
   // Declare a list of dependencies.
-  angular.module('crmMosaico', [
-    'crmUi', 'crmUtil', 'ngRoute', 'crmMailing'
-  ]);
+  angular.module('crmMosaico', CRM.angRequires('crmMosaico'));
 })(angular, CRM.$, CRM._);

--- a/ang/crmMosaico/BlockMailing.js
+++ b/ang/crmMosaico/BlockMailing.js
@@ -1,5 +1,5 @@
 (function(angular, $, _) {
-  angular.module('crmMosaico').directive('crmMosaicoBlockMailing', function($q, crmMetadata, crmUiHelp) {
+  angular.module('crmMosaico').directive('crmMosaicoBlockMailing', function($q, crmMetadata, crmUiHelp, crmMailingSimpleDirective) {
     return crmMailingSimpleDirective('crmMosaicoBlockMailing', '~/crmMosaico/BlockMailing.html');
   });
 })(angular, CRM.$, CRM._);


### PR DESCRIPTION
A couple changes in here:

* `crmMosaicoBlockMailing` - Fix crash when opening in Shoreditch (missing `crmMailingSimpleDirective`) (This resolves a regression from #249.)
* `crmMosaico` - Provide consistent dependency metadata on client+server