### PR TITLE
info.xml, README.md - Bump official dependency to 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This extension integrates a responsive email template editor, [Mosaico](http://m
 ## Requirements
 
 * CiviCRM
-    * Recommended: `v4.7.{latest}`
+    * Recommended: `v5.0`+
+    * Unofficial: `v4.7.{latest}`
     * Unofficial: `v4.6.26+` with [backports patch #9555](https://github.com/civicrm/civicrm-core/pull/9555)
 * PHP-ImageMagick
 * [FlexMailer](https://docs.civicrm.org/flexmailer/en/latest/) `v0.2-alpha5+`

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>2.0-beta4</version>
   <develStage>beta</develStage>
   <compatibility>
-    <ver>4.7</ver>
+    <ver>5.0</ver>
   </compatibility>
   <requires>
     <ext>org.civicrm.flexmailer</ext>


### PR DESCRIPTION
The 4.7 series is pretty long, and the extension is only really compatible
with later versions (mid/high-.20's -- haven't tested exactly).  However,
once we publish the stable release, it'll be presented in-app for all of
them.

This change doesn't make things any better or worse for 4.7 than they are
today. However, it means that (a) the in-app download only appears on 5.0+
and (b) we're not encouraging support/bug-reports from 4.7.