### PR TITLE
change name to prevent name clash

### DIFF
--- a/xml/schema/CRM/Mosaico/MessageTemplate.xml
+++ b/xml/schema/CRM/Mosaico/MessageTemplate.xml
@@ -2,7 +2,7 @@
 
 <table>
   <base>CRM/Mosaico</base>
-  <class>MessageTemplate</class>
+  <class>MosaicoMessageTemplate</class>
   <name>civicrm_mosaico_msg_template</name>
   <comment>Mosaico Templates Table</comment>
   <log>true</log>


### PR DESCRIPTION
'MessageTemplate' has the same name as a class in core, and the clash prevents  API calls from working correctly. See issue #278