### PR TITLE
Replacing 'TITLE' by mail subject in template HTML

### DIFF
--- a/ang/crmMosaico/MixinCtrl.js
+++ b/ang/crmMosaico/MixinCtrl.js
@@ -57,6 +57,12 @@
           // Mosaico exports JSON. Keep their original encoding... or else the loader throws an error.
           mailing.template_options.mosaicoMetadata = viewModel.exportMetadata();
           mailing.template_options.mosaicoContent = viewModel.exportJSON();
+          /*
+          Fix to display mailing subject instead of "TITLE"
+          Note that we're not validating subject since is a required field
+          and there is only one "TITLE" in the template
+           */
+          mailing.body_html = mailing.body_html.replace("TITLE", mailing.subject);
         }
 
         crmMosaicoIframe = new CrmMosaicoIframe({


### PR DESCRIPTION
In the mailings sent from CiviCRM, there's usually a "View in your browser" link (for when the mailing renders badly in the user's email client). When you visit that page, the page title is simple "TITLE".

This fix is replacing 'TITLE' by e-mail subject in generated HTML

This has been previously reported:
https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/issues/245