### PR TITLE
Refactor image backend. Conditionally use library which abstracts gd/imagemagick.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 packages/mosaico/
 node_modules/
+vendor/
 tests/backstop_data/cookies
 tests/backstop_data/screenshots
 tests/backstop_data/*_report

--- a/CRM/Mosaico/Form/MosaicoAdmin.php
+++ b/CRM/Mosaico/Form/MosaicoAdmin.php
@@ -11,6 +11,7 @@ class CRM_Mosaico_Form_MosaicoAdmin extends CRM_Admin_Form_Setting {
 
   protected $_settings = array(
     'mosaico_layout' => 'Mosaico Preferences',
+    'mosaico_graphics' => 'Mosaico Preferences',
     'mosaico_custom_templates_dir' => 'Mosaico Custom Templates Directory',
     'mosaico_custom_templates_url' => 'Mosaico Custom Templates URL'
   );

--- a/CRM/Mosaico/Graphics/Exception.php
+++ b/CRM/Mosaico/Graphics/Exception.php
@@ -1,0 +1,5 @@
+<?php
+
+class CRM_Mosaico_Graphics_Exception extends \CRM_Core_Exception {
+
+}

--- a/CRM/Mosaico/Graphics/Imagick.php
+++ b/CRM/Mosaico/Graphics/Imagick.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Class CRM_Mosaico_Graphics_Imagick
+ *
+ * A graphics provider which directly uses the imagick API.
+ *
+ * This is deprecated because we've had several random reports wherein
+ * imagick operations fail and we haven't been able to determine why.
+ */
+class CRM_Mosaico_Graphics_Imagick implements CRM_Mosaico_Graphics_Interface {
+
+  public function sendPlaceholder($width, $height) {
+    $image = new Imagick();
+
+    $image->newImage($width, $height, "#707070");
+    $image->setImageFormat("png");
+
+    $x = 0;
+    $y = 0;
+    $size = 40;
+
+    $draw = new ImagickDraw();
+
+    while ($y < $height) {
+      $draw->setFillColor("#808080");
+
+      $points = array(
+        array("x" => $x, "y" => $y),
+        array("x" => $x + $size, "y" => $y),
+        array("x" => $x + $size * 2, "y" => $y + $size),
+        array("x" => $x + $size * 2, "y" => $y + $size * 2),
+      );
+
+      $draw->polygon($points);
+
+      $points = array(
+        array("x" => $x, "y" => $y + $size),
+        array("x" => $x + $size, "y" => $y + $size * 2),
+        array("x" => $x, "y" => $y + $size * 2),
+      );
+
+      $draw->polygon($points);
+
+      $x += $size * 2;
+
+      if ($x > $width) {
+        $x = 0;
+        $y += $size * 2;
+      }
+    }
+
+    $draw->setFillColor("#B0B0B0");
+    $draw->setFontSize($width / 5);
+    $draw->setFontWeight(800);
+    $draw->setGravity(Imagick::GRAVITY_CENTER);
+    $draw->annotation(0, 0, $width . " x " . $height);
+
+    $image->drawImage($draw);
+
+    header("Content-type: image/png");
+
+    echo $image;
+  }
+
+}

--- a/CRM/Mosaico/Graphics/Imagick.php
+++ b/CRM/Mosaico/Graphics/Imagick.php
@@ -10,6 +10,15 @@
  */
 class CRM_Mosaico_Graphics_Imagick implements CRM_Mosaico_Graphics_Interface {
 
+  /**
+   * CRM_Mosaico_Graphics_Imagick constructor.
+   */
+  public function __construct() {
+    if (!extension_loaded('imagick') || !class_exists("Imagick")) {
+      throw new CRM_Mosaico_Graphics_Exception("Failed to locate PHP-ImageMagick extension.");
+    }
+  }
+
   public function sendPlaceholder($width, $height) {
     $image = new Imagick();
 

--- a/CRM/Mosaico/Graphics/Interface.php
+++ b/CRM/Mosaico/Graphics/Interface.php
@@ -21,4 +21,46 @@ interface CRM_Mosaico_Graphics_Interface {
    */
   public function sendPlaceholder($width, $height);
 
+  /**
+   * Generate a scaled version of the image.
+   *
+   * "resize" can receive one dimension to resize while keeping the A/R, or 2 to resize the image to be inside the dimensions.
+   *
+   * @see https://github.com/voidlabs/mosaico/blob/master/backend/README.txt
+   *
+   * @param string $src
+   *   Local file path.
+   * @param string $dest
+   *   Local file path.
+   * @param int|NULL $width
+   *   Width in pixels.
+   *   NOTE: NULL or 0 are interpreted "auto-scaled".
+   * @param int|NULL $height
+   *   Height in pixels.
+   *   NOTE: NULL or 0 are interpreted "auto-scaled".
+   * @return mixed
+   */
+  public function createResizedImage($src, $dest, $width, $height);
+
+  /**
+   * Generate a "cover" version of the image.
+   *
+   * "cover" will resize the image keeping the aspect ratio and covering the whole dimension (cutting it if different A/R)
+   *
+   * @see https://github.com/voidlabs/mosaico/blob/master/backend/README.txt
+   *
+   * @param string $src
+   *   Local file path.
+   * @param string $dest
+   *   Local file path.
+   * @param int|NULL $width
+   *   Width in pixels.
+   *   NOTE: NULL or 0 are interpreted "auto-scaled".
+   * @param int|NULL $height
+   *   Height in pixels.
+   *   NOTE: NULL or 0 are interpreted "auto-scaled".
+   * @return mixed
+   */
+  public function createCoveredImage($src, $dest, $width, $height);
+
 }

--- a/CRM/Mosaico/Graphics/Interface.php
+++ b/CRM/Mosaico/Graphics/Interface.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Interface CRM_Mosaico_Graphics_Interface
+ *
+ * This is an abstraction to help us among a couple graphics backends.
+ *
+ * NOTE: This interface has not been publicly documented because it's not
+ * been thought through very aggressively, and the contract could
+ * probably be better. As long as it remains internal, we have some
+ * flexibility to clean it up.
+ */
+interface CRM_Mosaico_Graphics_Interface {
+
+  /**
+   * Generate a placeholder image.
+   *
+   * @param int $width
+   * @param int $height
+   * @return mixed
+   */
+  public function sendPlaceholder($width, $height);
+
+}

--- a/CRM/Mosaico/Graphics/Intervention.php
+++ b/CRM/Mosaico/Graphics/Intervention.php
@@ -1,0 +1,84 @@
+<?php
+
+use CRM_Mosaico_ExtensionUtil as E;
+use Intervention\Image\ImageManagerStatic as Image;
+
+/**
+ * Class CRM_Mosaico_Graphics_Intervention
+ *
+ * @see http://image.intervention.io/getting_started/introduction
+ */
+class CRM_Mosaico_Graphics_Intervention implements CRM_Mosaico_Graphics_Interface {
+
+  const FONT_PATH = 'packages/mosaico/dist/vendor/notoregular/NotoSans-Regular-webfont.ttf';
+
+  /**
+   * CRM_Mosaico_Graphics_Intervention constructor.
+   *
+   * @param array $options
+   * @see Image::configure()
+   */
+  public function __construct($options) {
+    Image::configure($options);
+  }
+
+  public function sendPlaceholder($width, $height) {
+    $img = Image::canvas($width, $height, '#707070');
+
+    $x = 0;
+    $y = 0;
+    $size = 40;
+    while ($y < $height) {
+      $points = array(
+        ["x" => $x, "y" => $y],
+        ["x" => $x + $size, "y" => $y],
+        ["x" => $x + $size * 2, "y" => $y + $size],
+        ["x" => $x + $size * 2, "y" => $y + $size * 2],
+      );
+      $img->polygon(self::flattenPoints($points), function ($draw) {
+        $draw->background("#808080");
+      });
+      $points = array(
+        ["x" => $x, "y" => $y + $size],
+        ["x" => $x + $size, "y" => $y + $size * 2],
+        ["x" => $x, "y" => $y + $size * 2],
+      );
+      $img->polygon(self::flattenPoints($points), function ($draw) {
+        $draw->background("#808080");
+      });
+      $x += $size * 2;
+      if ($x > $width) {
+        $x = 0;
+        $y += $size * 2;
+      }
+    }
+    $img->text("{$width} x {$height}", $width / 2, $height / 2, function ($font) use ($width) {
+      $font->file(E::path(self::FONT_PATH));
+      $font->size($width / 5);
+      $font->align('center');
+      $font->valign('middle');
+      $font->color("#B0B0B0");
+    });
+
+    echo $img->response('png');
+  }
+
+  /**
+   * @param array $points
+   *   List of points; each is an array of "x","y" values.
+   *   Ex: $points[0]=['x'=>'100', 'y'=>'200'];
+   *   Ex: $points[1]=['x'=>'300', 'y'=>'400'];
+   * @return array
+   *   List of arrays. All "x","y" values indicated positoinally.
+   *   Ex: ['100','200','300','400'].
+   */
+  protected static function flattenPoints($points) {
+    $r = [];
+    foreach ($points as $point) {
+      $r[] = $point['x'];
+      $r[] = $point['y'];
+    }
+    return $r;
+  }
+
+}

--- a/CRM/Mosaico/Graphics/Intervention.php
+++ b/CRM/Mosaico/Graphics/Intervention.php
@@ -17,9 +17,20 @@ class CRM_Mosaico_Graphics_Intervention implements CRM_Mosaico_Graphics_Interfac
    *
    * @param array $options
    * @see Image::configure()
+   * @throws CRM_Mosaico_Graphics_Exception
    */
   public function __construct($options) {
+    if (!self::isClassLoaded()) {
+      throw new CRM_Mosaico_Graphics_Exception("Failed to locate classes for \"intervention/image\" API. Ensure that you have downloaded all dependencies.");
+    }
     Image::configure($options);
+  }
+
+  /**
+   * @return bool
+   */
+  public static function isClassLoaded() {
+    return class_exists('Intervention\Image\ImageManagerStatic');
   }
 
   public function sendPlaceholder($width, $height) {

--- a/CRM/Mosaico/ImageFilter.php
+++ b/CRM/Mosaico/ImageFilter.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Create absolute urls for Mosaico/imagemagick images when sending an email in CiviMail.
+ * Convert string below into just the absolute url with addition of static directory where correctly sized image is stored
+ * Mosaico image urls are in this format:
+ * img?src=BASE_URL+UPLOADS_URL+imagename+imagemagickparams
+ */
+class CRM_Mosaico_ImageFilter extends \Civi\FlexMailer\Listener\BaseListener {
+
+  /**
+   * @var array
+   * @see CRM_Mosaico_Utils::getConfig()
+   */
+  protected $config;
+
+  /**
+   * CRM_Mosaico_ImageFilter constructor.
+   * @param array $config
+   *   The active Mosaico path configuration.
+   */
+  public function __construct($config = NULL) {
+    $this->config = $config === NULL ? CRM_Mosaico_Utils::getConfig() : $config;
+  }
+
+  /**
+   * @see CRM_Utils_Hook::alterMailContent()
+   */
+  public function alterMailContent(\Civi\Core\Event\GenericHookEvent $e) {
+    if (!$this->isActive()) {
+      return;
+    }
+
+    $mosaico_image_upload_dir = rawurlencode($this->config['BASE_URL'] . $this->config['UPLOADS_URL']);
+
+    $e->content = preg_replace_callback(
+      "/src=\".+img\?src=(" . $mosaico_image_upload_dir . ")(.+)&.*\"/U",
+      function($matches){
+        return "src=\"" . rawurldecode($matches[1]) . "static/" . rawurldecode($matches[2]) . "\"";
+      },
+      $e->content
+    );
+  }
+
+}

--- a/CRM/Mosaico/Services.php
+++ b/CRM/Mosaico/Services.php
@@ -23,6 +23,7 @@ class CRM_Mosaico_Services {
     }
     $container->setDefinition('mosaico_flexmail_composer', new Definition('CRM_Mosaico_MosaicoComposer'));
     $container->setDefinition('mosaico_flexmail_url_filter', new Definition('CRM_Mosaico_UrlFilter'));
+    $container->setDefinition('mosaico_image_filter', new Definition('CRM_Mosaico_ImageFilter'));
     $container->setDefinition('mosaico_required_tokens', new Definition('CRM_Mosaico_MosaicoRequiredTokens'));
     $container->setDefinition('mosaico_graphics', new Definition('CRM_Mosaico_Graphics_Interface'))
       ->setFactory([__CLASS__, 'createGraphics']);
@@ -41,6 +42,7 @@ class CRM_Mosaico_Services {
     }
     $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_composer', 'onCompose'), FM::WEIGHT_MAIN);
     $listenerSpecs[] = array(FM::EVENT_COMPOSE, array('mosaico_flexmail_url_filter', 'onCompose'), FM::WEIGHT_ALTER - 100);
+    $listenerSpecs[] = ['hook_civicrm_alterMailContent', ['mosaico_image_filter', 'alterMailContent']];
 
     return $listenerSpecs;
   }

--- a/CRM/Mosaico/Services.php
+++ b/CRM/Mosaico/Services.php
@@ -4,6 +4,7 @@
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Civi\FlexMailer\FlexMailer as FM;
+use CRM_Mosaico_ExtensionUtil as E;
 
 /**
  * Class CRM_Mosaico_Services
@@ -68,14 +69,33 @@ class CRM_Mosaico_Services {
         return new CRM_Mosaico_Graphics_Imagick();
 
       case 'iv-gd':
+        self::applyAdhocClassloaderSafely();
         return new CRM_Mosaico_Graphics_Intervention(['driver' => 'gd']);
 
       case 'iv-imagick':
+        self::applyAdhocClassloaderSafely();
         return new CRM_Mosaico_Graphics_Intervention(['driver' => 'imagick']);
 
       default:
         // throw new \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException('mosaico_graphics');
         throw new CRM_Mosaico_Graphics_Exception("Failed to locate Mosaico graphics driver. Either \"mosaico_graphics\" is invalid or the autodetection failed.");
+    }
+  }
+
+  /**
+   * In a proper world, we would have one class-loader which captures
+   * all PHP packages for all extensions. We're not there.
+   *
+   * This conditionally loads "{mosaico}/vendor/autoload.php" (if available).
+   *
+   * We do not strictly require the file to exist -- e.g. if we find ourselves
+   * in a new world where there is one master class-loader, this still ought to
+   * work properly.
+   */
+  protected static function applyAdhocClassloaderSafely() {
+    $path = E::path('vendor/autoload.php');
+    if (file_exists($path)) {
+      require_once $path;
     }
   }
 

--- a/CRM/Mosaico/Services.php
+++ b/CRM/Mosaico/Services.php
@@ -54,11 +54,15 @@ class CRM_Mosaico_Services {
     // Apply translations for imprecise settings.
     switch ($graphics) {
       case 'auto':
-        if (extension_loaded('gd')) {
+        self::applyAdhocClassloaderSafely();
+        if (CRM_Mosaico_Graphics_Intervention::isClassLoaded() && extension_loaded('gd')) {
           $graphics = 'iv-gd';
         }
-        elseif (extension_loaded('imagick') && class_exists("Imagick")) {
+        elseif (CRM_Mosaico_Graphics_Intervention::isClassLoaded() && extension_loaded('imagick') && class_exists("Imagick")) {
           $graphics = 'iv-imagick';
+        }
+        elseif (!CRM_Mosaico_Graphics_Intervention::isClassLoaded() && extension_loaded('imagick') && class_exists("Imagick")) {
+          $graphics = 'imagick';
         }
         break;
     }
@@ -77,7 +81,6 @@ class CRM_Mosaico_Services {
         return new CRM_Mosaico_Graphics_Intervention(['driver' => 'imagick']);
 
       default:
-        // throw new \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException('mosaico_graphics');
         throw new CRM_Mosaico_Graphics_Exception("Failed to locate Mosaico graphics driver. Either \"mosaico_graphics\" is invalid or the autodetection failed.");
     }
   }

--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -276,56 +276,7 @@ class CRM_Mosaico_Utils {
       $height = (int) $params[1];
 
       if ($method == "placeholder") {
-        $image = new Imagick();
-
-        $image->newImage($width, $height, "#707070");
-        $image->setImageFormat("png");
-
-        $x = 0;
-        $y = 0;
-        $size = 40;
-
-        $draw = new ImagickDraw();
-
-        while ($y < $height) {
-          $draw->setFillColor("#808080");
-
-          $points = array(
-            array("x" => $x, "y" => $y),
-            array("x" => $x + $size, "y" => $y),
-            array("x" => $x + $size * 2, "y" => $y + $size),
-            array("x" => $x + $size * 2, "y" => $y + $size * 2),
-          );
-
-          $draw->polygon($points);
-
-          $points = array(
-            array("x" => $x, "y" => $y + $size),
-            array("x" => $x + $size, "y" => $y + $size * 2),
-            array("x" => $x, "y" => $y + $size * 2),
-          );
-
-          $draw->polygon($points);
-
-          $x += $size * 2;
-
-          if ($x > $width) {
-            $x = 0;
-            $y += $size * 2;
-          }
-        }
-
-        $draw->setFillColor("#B0B0B0");
-        $draw->setFontSize($width / 5);
-        $draw->setFontWeight(800);
-        $draw->setGravity(Imagick::GRAVITY_CENTER);
-        $draw->annotation(0, 0, $width . " x " . $height);
-
-        $image->drawImage($draw);
-
-        header("Content-type: image/png");
-
-        echo $image;
+        Civi::service('mosaico_graphics')->sendPlaceholder($width, $height);
       }
       else {
         $file_name = $_GET["src"];

--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -30,6 +30,21 @@ class CRM_Mosaico_Utils {
   }
 
   /**
+   * Get a list of graphics handling options.
+   *
+   * @return array
+   *   Array (string $machineName => string $label).
+   */
+  public static function getGraphicsOptions() {
+    return [
+      'auto' => E::ts('Automatically select a driver'),
+      'iv-gd' => E::ts('Intervention Image API (gd)'),
+      'iv-imagick' => E::ts('Intervention Image API (imagick)'),
+      'imagick' => E::ts('(Deprecated) Direct ImageMagick API'),
+    ];
+  }
+
+  /**
    * Get the path to the Mosaico layout file.
    *
    * @return string

--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -292,8 +292,12 @@ class CRM_Mosaico_Utils {
 
           $path_parts = pathinfo($_GET["src"]);
           $src_file = $config['BASE_DIR'] . $config['UPLOADS_DIR'] . $path_parts["basename"];
-          // $cache_file = $config['BASE_DIR'] . $config['STATIC_DIR'] . $path_parts["basename"]; // Old behavior - feels buggy
-          $cache_file = $config['BASE_DIR'] . $config['STATIC_DIR'] . $method . '-' . $width . "x" . $height . '-' . $path_parts["basename"];
+          $cache_file = $config['BASE_DIR'] . $config['STATIC_DIR'] . $path_parts["basename"];
+          // $cache_file = $config['BASE_DIR'] . $config['STATIC_DIR'] . $method . '-' . $width . "x" . $height . '-' . $path_parts["basename"];
+          // The current naming convention for cache-files is buggy because it means that all variants
+          // of the basename *must* have the same size, which breaks scenarios for re-using images
+          // from the gallery. However, to fix it, one must also fix CRM_Mosaico_ImageFilter.
+
           if (!file_exists($src_file)) {
             throw new \Exception("Failed to locate source file: " . $path_parts["basename"]);
           }

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -101,6 +101,9 @@ function do_download() {
     find node_modules -name '*.info' -delete
     grunt build
   popd >> /dev/null
+  pushd "$EXTROOT" >> /dev/null
+    composer install
+  popd >> /dev/null
 }
 
 ##############################
@@ -122,7 +125,7 @@ function do_zipfile() {
        ## Get any files in the project root, except for dotfiles.
        find . -mindepth 1 -maxdepth 1 -type f -o -type d | grep -v '^\./\.'
        ## Get any files in the main subfolders.
-       find CRM/ ang/ api/ bin/ css/ js/ sql/ sass/ settings/ templates/ tests/ xml/ -type f -o -type d
+       find CRM/ ang/ api/ bin/ css/ js/ sql/ sass/ settings/ templates/ tests/ vendor/ xml/ -type f -o -type d
        ## Get the distributable files for Mosaico.
        find packages/mosaico/{NOTICE,README,LICENSE,dist,templates}* -type f -o -type d
     } \

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "intervention/image": "^2.4"
+  }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,203 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "7053f968e2ac275e00bec7be5326a2b2",
+    "packages": [
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2017-03-20T17:10:46+00:00"
+        },
+        {
+            "name": "intervention/image",
+            "version": "2.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "e82d274f786e3d4b866a59b173f42e716f0783eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/e82d274f786e3d4b866a59b173f42e716f0783eb",
+                "reference": "e82d274f786e3d4b866a59b173f42e716f0783eb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "guzzlehttp/psr7": "~1.1",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.2",
+                "phpunit/phpunit": "^4.8 || ^5.7"
+            },
+            "suggest": {
+                "ext-gd": "to use GD library based image processing.",
+                "ext-imagick": "to use Imagick based image processing.",
+                "intervention/imagecache": "Caching extension for the Intervention Image library"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Intervention\\Image\\ImageServiceProvider"
+                    ],
+                    "aliases": {
+                        "Image": "Intervention\\Image\\Facades\\Image"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src/Intervention/Image"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@olivervogel.com",
+                    "homepage": "http://olivervogel.com/"
+                }
+            ],
+            "description": "Image handling and manipulation library with support for Laravel integration",
+            "homepage": "http://image.intervention.io/",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "laravel",
+                "thumbnail",
+                "watermark"
+            ],
+            "time": "2018-05-29T14:19:03+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/mosaico.php
+++ b/mosaico.php
@@ -197,11 +197,17 @@ function mosaico_civicrm_alterAPIPermissions($entity, $action, &$params, &$permi
  */
 function mosaico_civicrm_check(&$messages) {
   //Make sure the ImageMagick library is loaded.
-  if (!(extension_loaded('imagick') || class_exists("Imagick"))) {
+  try {
+    Civi::service('mosaico_graphics');
+  }
+  catch (CRM_Mosaico_Graphics_Exception $e) {
     $messages[] = new CRM_Utils_Check_Message(
-      'mosaico_imagick',
-      ts('the ImageMagick library is not installed.  The Email Template Builder extension will not work without it.'),
-      ts('ImageMagick not installed'),
+      'mosaico_graphics',
+      ts('Mosaico requires a graphics driver such as PHP-ImageMagick or PHP-GD. For more information, see <a href="%1">Mosaico Settings</a>.', [
+        1 => \CRM_Utils_System::url('civicrm/admin/mosaico', 'reset=1'),
+      ])
+      . "<p><em>" . ts("Error: %1", [1 => $e->getMessage()]) . "</em></p>",
+      ts('Graphics driver not available'),
       \Psr\Log\LogLevel::CRITICAL,
       'fa-chain-broken'
     );

--- a/mosaico.php
+++ b/mosaico.php
@@ -351,23 +351,6 @@ function _mosaico_civicrm_alterMailContent(&$content) {
     '[unsubscribe_link]' => '{action.unsubscribeUrl}',
   );
   $content = str_replace(array_keys($tokenAliases), array_values($tokenAliases), $content);
-
-  /**
-   * create absolute urls for Mosaico/imagemagick images when sending an email in CiviMail
-   * convert string below into just the absolute url with addition of static directory where correctly sized image is stored
-   * Mosaico image urls are in this format:
-   * img?src=BASE_URL+UPLOADS_URL+imagename+imagemagickparams
-   */
-  $mosaico_config = CRM_Mosaico_Utils::getConfig();
-  $mosaico_image_upload_dir = rawurlencode($mosaico_config['BASE_URL'] . $mosaico_config['UPLOADS_URL']);
-
-  $content = preg_replace_callback(
-    "/src=\".+img\?src=(" . $mosaico_image_upload_dir . ")(.+)&.*\"/U",
-    function($matches){
-      return "src=\"" . rawurldecode($matches[1]) . "static/" . rawurldecode($matches[2]) . "\"";
-    },
-    $content
-  );
 }
 
 /**

--- a/settings/Mosaico.setting.php
+++ b/settings/Mosaico.setting.php
@@ -21,6 +21,27 @@ return array(
     'description' => NULL,
     'help_text' => NULL,
   ),
+  'mosaico_graphics' => array(
+    'group_name' => 'Mosaico Preferences',
+    'group' => 'mosaico',
+    'name' => 'mosaico_graphics',
+    'quick_form_type' => 'Select',
+    'type' => 'String',
+    'html_type' => 'select',
+    'html_attributes' => array(
+      'class' => 'crm-select2',
+    ),
+    'pseudoconstant' => array(
+      'callback' => 'CRM_Mosaico_Utils::getGraphicsOptions',
+    ),
+    'default' => 'auto',
+    'add' => '4.7',
+    'title' => 'Mosaico graphics driver',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => NULL,
+    'help_text' => NULL,
+  ),
   'mosaico_custom_templates_dir' => array(
     'group_name' => 'Mosaico Preferences',
     'group' => 'mosaico',

--- a/templates/CRM/Mosaico/Form/MosaicoAdmin.tpl
+++ b/templates/CRM/Mosaico/Form/MosaicoAdmin.tpl
@@ -11,6 +11,13 @@
         <span class="description">{ts}How should the CiviMail composition screen look?{/ts}</span>
       </td>
     </tr>
+    <tr class="crm-mosaico-form-block-mosaico_graphics">
+      <td class="label">{$form.mosaico_graphics.label}</td>
+      <td>
+        {$form.mosaico_graphics.html}<br/>
+        <span class="description">{ts}Which backend should process images?{/ts}</span>
+      </td>
+    </tr>
     <tr class="crm-mosaico-form-block-mosaico_custom_templates_dir">
       <td class="label">
         {$form.mosaico_custom_templates_dir.label}

--- a/tests/phpunit/CRM/Mosaico/ImageFilterTest.php
+++ b/tests/phpunit/CRM/Mosaico/ImageFilterTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Civi\Test\EndToEndInterface;
+
+require_once __DIR__ . '/TestCase.php';
+
+/**
+ * Class CRM_Mosaico_UrlFilterTest
+ *
+ * Unit tests for filtering of URLs within HTML.
+ *
+ * @group e2e
+ */
+class CRM_Mosaico_ImageFilterTest extends CRM_Mosaico_TestCase implements EndToEndInterface {
+
+  public function filterExamples() {
+    $dmasterConfig = [
+      'BASE_URL' => 'http://dmaster.bknix:8001/sites/default/files/civicrm/persist/contribute/',
+      'BASE_DIR' => '/home/foobar/bknix/build/dmaster/sites/default/files/civicrm/persist/contribute/',
+      'UPLOADS_URL' => 'images/uploads/',
+      'UPLOADS_DIR' => 'images/uploads/',
+      'STATIC_URL' => 'images/uploads/static/',
+      'STATIC_DIR' => 'images/uploads/static/',
+      // 'THUMBNAILS_URL' => 'images/uploads/thumbnails/',
+      // 'THUMBNAILS_DIR' => 'images/uploads/thumbnails/',
+      // 'THUMBNAIL_WIDTH' => 90,
+      // 'THUMBNAIL_HEIGHT' => 90,
+      // 'MOBILE_MIN_WIDTH' => 246,
+    ];
+
+    $htmlTpl = '<p>Hello <img src="%s"> world.</p>';
+
+    $cases = array();
+
+    $cases[] = [
+      $dmasterConfig,
+      sprintf($htmlTpl, htmlentities('http://dmaster.bknix:8001/civicrm/mosaico/img?src=http%3A%2F%2Fdmaster.bknix%3A8001%2Fsites%2Fdefault%2Ffiles%2Fcivicrm%2Fpersist%2Fcontribute%2Fimages%2Fuploads%2FFileUploadBehavior_e76563d740531818a168bc5bd099b898.png&method=resize&params=534%2Cnull')),
+      sprintf($htmlTpl, htmlentities('http://dmaster.bknix:8001/sites/default/files/civicrm/persist/contribute/images/uploads/static/FileUploadBehavior_e76563d740531818a168bc5bd099b898.png')),
+    ];
+
+    return $cases;
+  }
+
+  /**
+   * @param string $inputHtml
+   * @param string $expectHtml
+   * @dataProvider filterExamples
+   */
+  public function testFilter($config, $inputHtml, $expectHtml) {
+    $filter = new CRM_Mosaico_ImageFilter($config);
+    $e = \Civi\Core\Event\GenericHookEvent::create([
+      'content' => [
+        'subject' => 'ignore',
+        'text' => 'ignore',
+        'html' => $inputHtml,
+      ]
+    ]);
+    $filter->alterMailContent($e);
+    $this->assertEquals('ignore', $e->content['subject']);
+    $this->assertEquals('ignore', $e->content['text']);
+    $this->assertEquals($expectHtml, $e->content['html']);
+  }
+
+}


### PR DESCRIPTION
Overview
--------

The image-handling code is derived from a example that uses ImageMagick. It works on many systems -- but, unfortunately, as we've seen in #186 (et al), there have been several reports where ImageMagick was installed but malfunctioning (for reasons that couldn't be positively determined). The typical symptom is that the placeholder images fail to render. It's been tricky because the key factors appear to be environmental -- so it was hard for me to reproduce.

Since switching my laptops to a new build system, I've started having this problem locally. That's good -- because I could reproduce; but it's still bad because (a) I don't know if I'm reproducing the same bug or just the same symptom and (b) it still proved difficult to debug.

This PR resolves the problem by abstracting away from ImageMagick. It should resolve or mitigate #137 and #186.

Before
-------
* All image-processing code was in `CRM_Mosaico_Utils`; it was hard-coded to use ImageMagick. If there was a problem with using ImageMagick, you were stuck.

After
------
* There are multiple image-processing drivers. 
* The class `CRM/Mosaico/Graphics/Intervention.php` uses the library [Intervention Image](http://image.intervention.io/getting_started/introduction). This library is a wrapper which can use `gd` or `imagick`.
* The class `CRM/Mosaico/Graphics/Imagick.php` is a refactored version of the old image-handling code. 
* The setting `mosaico_graphics` allows one to select a backend. The default value is `auto`; it should work on most systems out-of-the-box, but it provides some knobs to twiddle in case ImageMagick isn't working properly.

![image](https://user-images.githubusercontent.com/1336047/48812951-86543200-ece9-11e8-9713-387624c6c169.png)


Comments
--------------
* We should treat `CRM/Mosaico/Graphics/Imagick.php` as deprecated -- i.e. the `Intervention`-based driver works in more environments with nicer code (e.g. compatible with `gd` and `imagick`). However, I'm keeping it for the moment because it's hard to verify interoperability in every edge-case.
* It's not very appealing to expose a setting for the image-backend, but it seems like a necessary evil -- we do not have the range of environments (or time) needed to verify that the autodetected drivers work consistently. Providing a setting means that sysadmins have an escape-clause when there are unexpected problems with the backends.
* ~~I vaguely recall some reports about issues with re-resizing images from the gallery. (Maybe via @guanhuan or someone else from Compucorp?) Not sure if that was filed properly,  but it smelled like a cache bug (i.e. the 1st scaled image was cached and reused as the 2nd scaled image -- even if they were supposed to be scaled to different sizes). This should be incidentally addressed for anyone using the `CRM/Mosaico/Graphics/Intervention.php` driver. However, since I don't have a report, I can't comment definitively. I'd recommend anyone keen on that re-test.~~
    * UPDATE: I found that fixing the cache-naming bug (which is hard to see/experience) causes a more prominent bug -- there's an `alterMailContent` filter for images which links directly to the image files, so any change in naming convention breaks that. Since this wasn't really the main purpose of the PR, I've switched back to the existing behavior. Those two things (cache naming and image filtering) should be updated in tandem -- but separate from this PR.
* With regards to testing... I have checked the image-handling URLs directly with about a dozen different inputs (different actions with null/low/high vales for various params; based on a few examples generated organically in Mosaico UI). However, I have *not* done a [full battery of manual integration tests](https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/blob/2.x/TESTING.md).