### PR TITLE
Allow sending traditional ad-hoc emails as a search task

### DIFF
--- a/CRM/Mosaico/Form/Task/AdhocMailingTraditional.php
+++ b/CRM/Mosaico/Form/Task/AdhocMailingTraditional.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Given the selected contacts, prepare a *traditional* mailing with a hidden group.
+ */
+class CRM_Mosaico_Form_Task_AdhocMailingTraditional extends CRM_Contact_Form_Task {
+
+  public function preProcess() {
+    parent::preProcess();
+    $templateTypes = \CRM_Mailing_BAO_Mailing::getTemplateTypes();
+    foreach ($templateTypes as $key => $templateType) {
+      if ($templateType['name'] == 'traditional') {
+        $tradTemplateType = $key;
+      }
+    }
+    list ($groupId) = $this->createHiddenGroup();
+    $mailing = civicrm_api3('Mailing', 'create', array(
+      'name' => "",
+      'campaign_id' => NULL,
+      'replyto_email' => "",
+      'template_type' => $templateTypes[$tradTemplateType]['name'],
+      'template_options' => array('nonce' => 1),
+      'subject' => "",
+      'body_html' => "",
+      'body_text' => "",
+      'groups' => array(
+        'include' => array($groupId),
+        'exclude' => array(),
+        'base' => array(),
+      ),
+      'mailings' => array(
+        'include' => array(),
+        'exclude' => array(),
+      ),
+    ));
+
+    CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mailing/' . $mailing['id']));
+  }
+}
+  

--- a/mosaico.php
+++ b/mosaico.php
@@ -414,3 +414,15 @@ function mosaico_civicrm_container(\Symfony\Component\DependencyInjection\Contai
   require_once 'CRM/Mosaico/Services.php';
   CRM_Mosaico_Services::registerServices($container);
 }
+
+/**
+ * Implements hook_civicrm_searchTasks();
+ */
+function mosaico_civicrm_searchTasks($objectName, &$tasks) {
+  if ($objectName == 'contact') {
+    $tasks[] = [
+      'title' => 'Email - schedule/send via CiviMail (traditional)',
+      'class' => 'CRM_Mosaico_Form_Task_AdhocMailingTraditional',
+    ];
+  }
+}


### PR DESCRIPTION
Newer betas of Mosaico 2.x allow creating a non-Mosaico CiviMail through **Mailings » New Mailing (Traditional)**.  However, there is no equivalent for creating an ad-hoc mailing via the search action "Email - Schedule/send via CiviMail".

This PR adds a new search action: "Email - Schedule/send via CiviMail (traditional)" which allows creating ad-hoc mailings using traditional templates.