### PR TITLE
Always place iframe below KAM menu instead of underneath.

### DIFF
--- a/ang/crmMosaico/Iframe.js
+++ b/ang/crmMosaico/Iframe.js
@@ -26,15 +26,7 @@
           var c = CRM.crmMosaico || {};
           var top = 0, left = 0, width = $(window).width(), height = $(window).height();
           if (c.topNav && $(c.topNav).length > 0) {
-            if (c.drupalNav && $(c.drupalNav).length > 0 && $(c.drupalNav).outerHeight() > $(c.topNav).outerHeight()) {
-              top = $(c.drupalNav).outerHeight();
-            }
-            else if (c.joomlaNav && $(c.joomlaNav).length > 0 && $(c.joomlaNav).outerHeight() > $(c.topNav).outerHeight()) {
-              top = $(c.joomlaNav).outerHeight();
-            }
-            else {
-              top = $(c.topNav).outerHeight();
-            }
+            top = $(c.topNav).outerHeight() + $(c.topNav).position().top;
             height -= top;
           }
           if (c.leftNav && $(c.leftNav).length > 0) {


### PR DESCRIPTION
Since the introduction of the KAM menu into core we have a consistent css ID across CMSs `#civicrm-menu`.

So we can: 
1. Simplify code to position the iframe.
2. Always align the iframe below the KAM menu no matter what position it is currently in (ie. overlapping/below the CMS menu).

I've tested this on Joomla, Drupal7 and Wordpress and seems to work well on all three.  Only "nice-to-have" is to trigger a reposition of the iframe if the KAM menu is moved (as is triggered on window resize) but that doesn't feel essential and I couldn't see how to trigger that easily.

Ping @colemanw