### PR TITLE
Replace '<title>TITLE</title>' with subject (render-time)

### DIFF
--- a/mosaico.php
+++ b/mosaico.php
@@ -351,6 +351,9 @@ function _mosaico_civicrm_alterMailContent(&$content) {
     '[unsubscribe_link]' => '{action.unsubscribeUrl}',
   );
   $content = str_replace(array_keys($tokenAliases), array_values($tokenAliases), $content);
+
+  // Some existing and customized templates have awkward HTML <TITLE>s, which show up when viewing the mailing the browser.
+  $content = preg_replace(';(\<head.*\<title\>\s*)TITLE(\s*\</title\>.*\</head\>);ms', '\\1{mailing.subject}\\2', $content, 1);
 }
 
 /**


### PR DESCRIPTION
This is a revision of #280.  It uses a tighter search/replace pattern so
that it only matches "TITLE" when its nested inside `<head>` and `<title>`
elements.  Additionally, it applies the filter at render-time, which means
it will apply to new-or-existing mailings/templates (whether
stock-or-customized; with or without https://github.com/civicrm/mosaico/pull/4).

Note: This patch and mosaico#4 address the same pain-point, but they're not redundant because:

* With or without this patch, mosaico#4 provides better readability/writeability in the base template.
* With or without mosaico#4, the present commit provides more backward/forward compatibility.