### PR TITLE
Improve image processor validation

### DIFF
--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -10,6 +10,13 @@ use CRM_Mosaico_ExtensionUtil as E;
  */
 class CRM_Mosaico_Utils {
 
+  /**
+   * Maximum image size, in total pixels, allowed for on-the-fly generation.
+   *
+   * @var int
+   */
+  const MAX_IMAGE_PIXELS = 36000000;
+
   public static function isBootstrap() {
     return strpos(CRM_Mosaico_Utils::getLayoutPath(), '/crmstar-') === FALSE;
   }
@@ -281,9 +288,9 @@ class CRM_Mosaico_Utils {
       $width = (int) $params[0];
       $height = (int) $params[1];
 
-      // Apply a sensible maximum for images in an email
-      if ($width > 6000 || $height > 6000) {
-        throw new \Exception("The requested dimensions are too large");
+      // Apply a sensible maximum size for images in an email
+      if ($width * $height > self::MAX_IMAGE_PIXELS)  {
+        throw new \Exception("The requested image size is too large");
       }
 
       switch ($method) {

--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -281,8 +281,19 @@ class CRM_Mosaico_Utils {
       $width = (int) $params[0];
       $height = (int) $params[1];
 
+      // Apply a sensible maximum for images in an email
+      if ($width > 6000 || $height > 6000) {
+        throw new \Exception("The requested dimensions are too large");
+      }
+
       switch ($method) {
         case 'placeholder':
+
+          // Only privileged users can request generation of placeholders
+          if (!CRM_Core_Permission::check(['access CiviMail', 'create mailings', 'edit message templates'])) {
+            CRM_Utils_System::permissionDenied();
+          }
+
           Civi::service('mosaico_graphics')->sendPlaceholder($width, $height);
           break;
 


### PR DESCRIPTION
Improve validation in the image processor to ensure that super-sized images cannot be generated on the fly, and improve access control so that only people who can create mailings can request placeholder images.

One consequence of this is that it if you send a 'test' of an email to an unauthenticated user, any dynamically generated placeholders will not load.