### PR TITLE
Replace the image source to static url and remove placeholder before sending

### DIFF
--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -313,6 +313,34 @@ class CRM_Mosaico_Utils {
   }
 
   /**
+   * Called in hook_civicrm_alterMailContent
+   * Generate the static image and return the static url for the image
+   *
+   * @param array $matches
+   *                      The regex matches
+   *
+   * @return string
+   *               The static url
+   */
+  public static function cacheImage($matches) {
+    $url = urldecode(html_entity_decode($matches[1]));
+    parse_str(parse_url($url, PHP_URL_QUERY), $params);
+
+    // No placeholder
+    if ($params['method'] == 'placeholder') {
+      return '';
+    }
+    // Generate the static image by visiting the URL
+    file_get_contents($url);
+
+    $config = self::getConfig();
+    $path_parts = pathinfo($params['src']);
+    $static_url = $config['BASE_URL'] . $config['STATIC_URL'] . $path_parts["basename"];
+    // Civi::log()->info("static url: ".$static_url);
+    return 'src="'. $static_url . '"';
+  }
+
+  /**
    * @param string $file
    *   Full path to the image file.
    */

--- a/mosaico.php
+++ b/mosaico.php
@@ -408,6 +408,17 @@ function mosaico_civicrm_pre($op, $objectName, $id, &$params) {
 }
 
 /**
+ * Implements hook_civicrm_alterMailContent(&$content).
+ * @param array $content
+ */
+function mosaico_civicrm_alterMailContent(&$content) {
+  if (isset($content['html'])) {
+    $re = '|src="(.*q=civicrm(%2F\|/)mosaico(%2F\|/)img&.*)"|';
+    $content['html'] = preg_replace_callback($re, 'CRM_Mosaico_Utils::cacheImage', $content['html']);
+  }
+}
+
+/**
  * Implements hook_civicrm_container().
  */
 function mosaico_civicrm_container(\Symfony\Component\DependencyInjection\ContainerBuilder $container) {


### PR DESCRIPTION
Overview
----------
One of our clients is experiencing a performance issue every time when the Mosaico mailing send out. We found that a lot of Mosaico image request is logged and want to reduce the load on each image request.
The URL in Mosaico editor includes an image processor to resize the source image. Though it will cache the resized image, it still needs to bootstrap the CMS and CiviCRM every time.

Before
---------
The image URL is `src="https://domain/civicrm?page=CiviCRM&amp;q=civicrm%2Fmosaico%2Fimg&amp;src={source_url}&amp;method=resize&amp;params=258%2Cnull"`

After
---------
The image URL is `https://domain/wp-content/uploads/civicrm/persist/contribute/images/uploads/static/{filename}`

Note
---------
I tried to find a way to let Mosaico generating the static URL instead of replacing but cannot find a way to do it.

Agileware ref: CIVIMOSAIC-19