### PR TITLE
github#336 Add translation support

### DIFF
--- a/CRM/Mosaico/Page/Editor.php
+++ b/CRM/Mosaico/Page/Editor.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Mosaico_ExtensionUtil as E;
+
 class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
   const DEFAULT_MODULE_WEIGHT = 200;
 
@@ -98,6 +100,14 @@ class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
         'toolbar1' => 'bold italic forecolor backcolor hr styleselect removeformat | civicrmtoken | link unlink | pastetext code',
       ),
     );
+
+    // Adding translation strings if exist
+    $locale = CRM_Core_I18n::getLocale();
+    $lang = CRM_Core_I18n_PseudoConstant::shortForLong($locale);
+    $translationFile = CRM_Core_Resources::singleton()->getPath(E::LONG_NAME, "packages/mosaico/res/lang/mosaico-{$lang}.json");
+    if (file_exists($translationFile)) {
+      $config['strings'] = json_decode(file_get_contents($translationFile));
+    }
 
     // Allow configuration to be modified by a hook
     if (class_exists('\Civi\Core\Event\GenericHookEvent')) {


### PR DESCRIPTION
Based on @mattwire proof of concept https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/pull/337, adding mosaico editor translation based on the user language.

I have tested the following:
- multilingual site with 3 locales -> switching between locales works well and uses the corresponding locale strings
- removing a language file -> no error message, the editor is in English as expected
