### PR TITLE
Change image placeholder permissions

### DIFF
--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -297,7 +297,7 @@ class CRM_Mosaico_Utils {
         case 'placeholder':
 
           // Only privileged users can request generation of placeholders
-          if (!CRM_Core_Permission::check(['access CiviMail', 'create mailings', 'edit message templates'])) {
+          if (!CRM_Core_Permission::check([['access CiviMail', 'create mailings', 'edit message templates']])) {
             CRM_Utils_System::permissionDenied();
           }
 


### PR DESCRIPTION
Changes the image placeholder permissions check to use OR instead of AND when evaluating required perms.