### PR TITLE
Make spell check available directly in mosaico

### DIFF
--- a/CRM/Mosaico/Page/Editor.php
+++ b/CRM/Mosaico/Page/Editor.php
@@ -94,6 +94,7 @@ class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
             ts('Contact ID') => '{contact.contact_id}',
           ),
         ),
+        'browser_spellcheck' => TRUE,
       ),
       'tinymceConfigFull' => array(
         'plugins' => array('link hr paste lists textcolor code civicrmtoken'),


### PR DESCRIPTION
While many browsers natively support spell check, TinyMCE has it turned off in mosaico. 
We've had many requests for it, and it really make sense for a template editor to support it by default.

Although it could also be achieved by using extensions that implement mosaicoConfig hook, having another extension just for spell check is maintenance overhead. 

Related issue #259.