### PR TITLE
Allow extensions to enable smarty in the tokenprocessor context

### DIFF
--- a/CRM/Mosaico/MosaicoComposer.php
+++ b/CRM/Mosaico/MosaicoComposer.php
@@ -18,8 +18,8 @@ class CRM_Mosaico_MosaicoComposer extends \Civi\FlexMailer\Listener\DefaultCompo
     \Civi\FlexMailer\Event\ComposeBatchEvent $e
   ) {
     $context = parent::createTokenProcessorContext($e);
-    // Smarty would break Mosaico CSS.
-    $context['smarty'] = FALSE;
+    // Smarty would break Mosaico CSS unless we know what we are doing (eg. handling via extension)
+    $context['smarty'] = $e->context['smarty'] ?? FALSE;
     return $context;
   }
 


### PR DESCRIPTION
For example:
```
  Civi::dispatcher()->addListener('civi.flexmailer.compose', 'myextension_symfony_civicrm_flexmailer_compose', \Civi\FlexMailer\FlexMailer::WEIGHT_PREPARE);
```
```
function myextension_symfony_civicrm_flexmailer_compose($event, $hook) {
  $event->context['smarty'] = TRUE;
}
```