### PR TITLE
Clean any possible output buffers. 

### DIFF
--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -287,6 +287,13 @@ class CRM_Mosaico_Utils {
         throw new \Exception("The requested image size is too large");
       }
 
+      // Sometimes output buffer started by another module or plugin causes problem with
+      // image rendering. Let's clean any such buffers.
+      $levels = ob_get_level();
+      for ($i = 0; $i < $levels; $i++) {
+        ob_end_clean();
+      }
+
       switch ($method) {
         case 'placeholder':
 


### PR DESCRIPTION
Sometimes output buffer started by another module or plugin causes problem with image rendering. The patch cleans any output buffers.

The patch has helped quite a few folks. See https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/issues/292, https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/issues/373. And is CMS agnostic, although most of the cases have been experienced on wordpress. 
