### PR TITLE
Warn user before clicking away from mosaico editor

### DIFF
--- a/templates/CRM/Mosaico/Page/EditorIframe.tpl
+++ b/templates/CRM/Mosaico/Page/EditorIframe.tpl
@@ -27,7 +27,7 @@
 
       window.onbeforeunload = function(e) {
         e.preventDefault();
-        e.returnValue = "Do you really want to leave our brilliant application?";
+        e.returnValue = "{/literal}{ts}Exit email composer without saving?{/ts}{literal}";
       };
 
       if (window.top.crmMosaicoIframe) {

--- a/templates/CRM/Mosaico/Page/EditorIframe.tpl
+++ b/templates/CRM/Mosaico/Page/EditorIframe.tpl
@@ -24,6 +24,12 @@
 
       var plugins = [];
       var config = {/literal}{$mosaicoConfig}{literal};
+
+      window.onbeforeunload = function(e) {
+        e.preventDefault();
+        e.returnValue = "Do you really want to leave our brilliant application?";
+      };
+
       if (window.top.crmMosaicoIframe) {
         window.top.crmMosaicoIframe(window, Mosaico, config, plugins);
       }


### PR DESCRIPTION
This pops up a "browser" warning - "Are you sure you want to navigate away from this page?" using the standard `window.onbeforeunload` function. The custom message may or may not display depending on browser (it did not in Chrome 84).

@bhumanists @petednz @agileware-justin @artfulrobot @deepak-srivastava please test and let me know if this is more helpful for your users in or out!