### PR TITLE
Fix layout autodetection vis-a-vis Shoreditch

### DIFF
--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -99,7 +99,8 @@ class CRM_Mosaico_Utils {
     ];
 
     if (empty($layout) || $layout === 'auto') {
-      return CRM_Extension_System::singleton()->getMapper()->isActiveModule('shoreditch')
+      $themes = Civi::service('themes');
+      return $themes->getActiveThemeKey() === 'shoreditch'
         ? $paths['bootstrap-wizard'] : $paths['crmstar-single'];
     }
     elseif (isset($paths[$layout])) {


### PR DESCRIPTION
Background
----------

The setting `mosaico_layout` defaults to `auto`. In this mode, it looks for Shoreditch and then
loads appropriate HTML/CSS (depending on whether it's installed).

Before
------

There's a subtle bug. Example situation:

1. Install Shoreditch
2. Neglect to set Shoreditch as the active theme
3. Navigate to "New Mailing"
4. The layout looks messy.

The problem is that the auto-detection rule is checking whether the
Shoreditch codebase *exists* -- not whether the Shoreditch look-and-feel is
being used on the current page-view.

The example above arises from misconfiguration.  A similar bug would also
arise if you had another customization which used hooks to toggle the active theme.

After
-----

The autodetection cares about whether Shoreditch is being used on this page-view.

Comments
--------

The general arrangement is still overly coupled and could be improved.  But
this at least makes it behave better and is minimal/safe/low-QA-work.