### PR TITLE
placeholder images not accessible in joomla

### DIFF
--- a/CRM/Mosaico/Page/Editor.php
+++ b/CRM/Mosaico/Page/Editor.php
@@ -65,6 +65,7 @@ class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
 
     $config = [
       'imgProcessorBackend' => $this->getUrl('civicrm/mosaico/img', NULL, TRUE),
+      'imgPlaceholderUrl' => $this->getUrl('civicrm/mosaico/img/placeholder', NULL, FALSE),
       'emailProcessorBackend' => 'unused-emailProcessorBackend',
       'titleToken' => 'MOSAICO Responsive Email Designer',
       'fileuploadConfig' => [

--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -326,16 +326,6 @@ class CRM_Mosaico_Utils {
 
       switch ($method) {
         case 'placeholder':
-
-          // Only privileged users can request generation of placeholders
-          // Skip permission check for Joomla as backend base url (example.org/administrator) is separate from
-          // frontend url (example.org/index.php) and civicrm/mosaico/img url is frontend.
-          if (CRM_Core_Config::singleton()->userFramework != 'Joomla' &&
-            !CRM_Core_Permission::check([['access CiviMail', 'create mailings', 'edit message templates']])
-          ) {
-            CRM_Utils_System::permissionDenied();
-          }
-
           Civi::service('mosaico_graphics')->sendPlaceholder($width, $height);
           break;
 

--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -328,7 +328,11 @@ class CRM_Mosaico_Utils {
         case 'placeholder':
 
           // Only privileged users can request generation of placeholders
-          if (!CRM_Core_Permission::check([['access CiviMail', 'create mailings', 'edit message templates']])) {
+          // Skip permission check for Joomla as backend base url (example.org/administrator) is separate from
+          // frontend url (example.org/index.php) and civicrm/mosaico/img url is frontend.
+          if (CRM_Core_Config::singleton()->userFramework != 'Joomla' &&
+            !CRM_Core_Permission::check([['access CiviMail', 'create mailings', 'edit message templates']])
+          ) {
             CRM_Utils_System::permissionDenied();
           }
 

--- a/xml/Menu/mosaico.xml
+++ b/xml/Menu/mosaico.xml
@@ -27,6 +27,12 @@
     <access_arguments>access CiviMail;create mailings;edit message templates</access_arguments>
   </item>
   <item>
+    <path>civicrm/mosaico/img/placeholder</path>
+    <page_callback>CRM_Mosaico_Utils::processImg</page_callback>
+    <title>Integration with Mosaico</title>
+    <access_arguments>access CiviMail;create mailings;edit message templates</access_arguments>
+  </item>
+  <item>
     <path>civicrm/mosaico/img</path>
     <page_callback>CRM_Mosaico_Utils::processImg</page_callback>
     <title>Integration with Mosaico</title>

--- a/xml/Menu/mosaico.xml
+++ b/xml/Menu/mosaico.xml
@@ -30,6 +30,7 @@
     <path>civicrm/mosaico/img/placeholder</path>
     <page_callback>CRM_Mosaico_Utils::processImg</page_callback>
     <title>Integration with Mosaico</title>
+    <access_callback>CRM_Core_Permission::checkMenu</access_callback>
     <access_arguments>access CiviMail;create mailings;edit message templates</access_arguments>
   </item>
   <item>


### PR DESCRIPTION
Since placeholder images were permissioned, placeholder images have gone missing for Joomla installs.

This is mainly because in Joomla backend backend url (example.org/administrator) is separate from frontend url (example.org/index.php) and civicrm/mosaico/img url is frontend. See following screenshot:

![image](https://user-images.githubusercontent.com/3448551/97728174-210a3d80-1ac9-11eb-865e-1b5ab291cd92.png)

The issue was also discussed [here](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/issues/340#issuecomment-550557572). 

UPDATE:
- PR creates a new separate url for placeholder images which is populated as a backend url with it's own permissions - civicrm/mosaico/img/placeholder
- Also dependent on PR to mosaico library - https://github.com/civicrm/mosaico/pull/6
