### PR TITLE
Fix Leave site? warning when not required

### DIFF
--- a/templates/CRM/Mosaico/Page/EditorIframe.tpl
+++ b/templates/CRM/Mosaico/Page/EditorIframe.tpl
@@ -26,7 +26,7 @@
       var config = {/literal}{$mosaicoConfig}{literal};
       
       window.addEventListener('beforeunload', function(e) {
-        if(window.parent.document.getElementsByTagName('iframe')[0].style.display !== "none") {
+        if(window.parent.document.getElementById('crm-mosaico').style.display !== "none") {
           e.preventDefault();
           e.returnValue = "{/literal}{ts}Exit email composer without saving?{/ts}{literal}";
         }

--- a/templates/CRM/Mosaico/Page/EditorIframe.tpl
+++ b/templates/CRM/Mosaico/Page/EditorIframe.tpl
@@ -24,11 +24,13 @@
 
       var plugins = [];
       var config = {/literal}{$mosaicoConfig}{literal};
-
-      window.onbeforeunload = function(e) {
-        e.preventDefault();
-        e.returnValue = "{/literal}{ts}Exit email composer without saving?{/ts}{literal}";
-      };
+      
+      window.addEventListener('beforeunload', function(e) {
+        if(window.parent.document.getElementsByTagName('iframe')[0].style.display !== "none") {
+          e.preventDefault();
+          e.returnValue = "{/literal}{ts}Exit email composer without saving?{/ts}{literal}";
+        }
+      });
 
       if (window.top.crmMosaicoIframe) {
         window.top.crmMosaicoIframe(window, Mosaico, config, plugins);


### PR DESCRIPTION
Before: Leave site? warning was triggered by onbeforeunload when saving the mailing draft or submitting the mailing and otherwise leaving the mailing (after the user had edited the design of the mailing).

After: Leave site? warning is only triggered when leaving the mailing while editing the mailing design in Mosaico and not in the CiviCRM parts of the mailing editor.

This change just checks if the Mosaico iframe is shown on the mailing editing page before triggering the Leave site? warning and does not trigger the warning if the iframe is not currently shown.