### PR TITLE
Throw error message on resizing image and prevent hard fail

### DIFF
--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -274,14 +274,21 @@ class CRM_Mosaico_Utils {
             $size = filesize($file_path);
 
             $thumbnail_path = $config['BASE_DIR'] . $config[ 'THUMBNAILS_DIR' ] . $file_name;
-            Civi::service('mosaico_graphics')->createResizedImage($file_path, $thumbnail_path, $config['THUMBNAIL_WIDTH'], $config['THUMBNAIL_HEIGHT']);
-
-            $file = [
-              "name" => $file_name,
-              "url" => $config['BASE_URL'] . $config['UPLOADS_DIR'] . $file_name,
-              "size" => $size,
-              "thumbnailUrl" => $config['BASE_URL'] . $config['THUMBNAILS_URL'] . $file_name,
-            ];
+            try {
+              Civi::service('mosaico_graphics')->createResizedImage($file_path, $thumbnail_path, $config['THUMBNAIL_WIDTH'], $config['THUMBNAIL_HEIGHT']);
+              $file = [
+                "name" => $file_name,
+                "url" => $config['BASE_URL'] . $config['UPLOADS_DIR'] . $file_name,
+                "size" => $size,
+                "thumbnailUrl" => $config['BASE_URL'] . $config['THUMBNAILS_URL'] . $file_name,
+              ];
+            }
+            catch (\Exception $e) {
+              CRM_Core_Error::debug_log_message($e->getMessage());
+              $file = [
+                'error' => $e->getMessage(),
+              ];
+            }
 
             $files[] = $file;
           }


### PR DESCRIPTION
Mosaico uses the Intervention library to handle image manipulation. we've found a few instances where this throws a fatal error and breaks the application, when we think it should log an error to file, perhaps throw a  UI warning -- but not block use of the system. Two cases where it causes hard failure:
1.  Files in the images/uploads folder (i.e. the Mosaico gallery) had improper permissions, and
2. when there were files there that were not valid image files.

BEFORE
---------
Hard failure breaks the design screen

AFTER
-------
Capture the error messages and notify the user on compose screen. 

