### PR TITLE
Specify to use bootstrap3 bundle if in bootstrap mode

### DIFF
--- a/ang/crmMosaico.ang.php
+++ b/ang/crmMosaico.ang.php
@@ -32,5 +32,6 @@ $result = [
 ];
 
 $result['css'][]= ($result['settings']['useBootstrap']) ? 'css/mosaico-bootstrap.css' : 'css/mosaico-crmstar.css';
+$result['bundles']= ($result['settings']['useBootstrap']) ? ['bootstrap3'] : [];
 
 return $result;

--- a/ang/crmbWizard.ang.php
+++ b/ang/crmbWizard.ang.php
@@ -12,6 +12,7 @@ return [
   ],
   // Hmm, shouldn't high-level components have separate CSS files?
   'css' => CRM_Mosaico_Utils::isBootstrap() ? ['css/mosaico-bootstrap.css'] : [],
+  'bundles' => CRM_Mosaico_Utils::isBootstrap() ? ['bootstrap3'] : [],
   'partials' =>
   [
     0 => 'ang/crmbWizard',

--- a/info.xml
+++ b/info.xml
@@ -19,7 +19,7 @@
   <version>2.6</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.28</ver>
+    <ver>5.35</ver>
   </compatibility>
   <requires>
     <ext version="~1.1">org.civicrm.flexmailer</ext>


### PR DESCRIPTION
ping @mattwire @colemanw @totten This is to be consistent with https://github.com/civicrm/civicrm-core/blob/5db0bc3c1f54eaca4307f103a73bda596ae914d6/ext/search/ang/crmSearchDisplayList.ang.php#L13 