### PR TITLE
Add hooks to alter relevant assets in the Mosaico interface

### DIFF
--- a/CRM/Mosaico/Page/EditorIframe.php
+++ b/CRM/Mosaico/Page/EditorIframe.php
@@ -2,4 +2,29 @@
 
 class CRM_Mosaico_Page_EditorIframe extends CRM_Mosaico_Page_Editor {
 
+  /**
+   * Modify return value of parent:: method.
+   */
+  protected function getScriptUrls() {
+    $scriptUrls = parent::getScriptUrls();
+
+    CRM_Utils_Hook::singleton()->invoke(['scriptUrls'], $scriptUrls, $null, $null,
+      $null, $null, $null,
+      'civicrm_mosaicoScriptUrlsAlter'
+    );
+    return $scriptUrls;
+  }
+
+  /**
+   * Modify return value of parent:: method.
+   */
+  protected function getStyleUrls() {
+    $styleUrls = parent::getStyleUrls();
+
+    CRM_Utils_Hook::singleton()->invoke(['styleUrls'], $styleUrls, $null, $null,
+      $null, $null, $null,
+      'civicrm_mosaicoStyleUrlsAlter'
+    );
+    return $styleUrls;
+  }
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -83,29 +83,6 @@ Example from  [Campaign Advocacy](https://github.com/twomice/civicrm-campaignadv
 ```php
 function campaignadv_civicrm_mosaicoStyleUrlsAlter(&$styleUrls) {
   $res = CRM_Core_Resources::singleton();
-  $snippets = array_merge(Civi::service('bundle.coreResources')->getAll(), Civi::service('bundle.coreStyles')->getAll());
-
-  // crm-i.css added ahead of other styles so it can be overridden by FA.
-  array_unshift($styleUrls, $res->getUrl('civicrm', 'css/crm-i.css', TRUE));
-
-  foreach ($snippets as $snippet) {
-    $itemUrl = NULL;
-    if (
-      FALSE !== strpos($snippet['name'], 'css')
-      // Exclude jquery ui theme styles, which conflict with Mosaico styles.
-      && FALSE === strpos($snippet['name'], '/jquery-ui/themes/')
-    ) {
-      if ($snippet['styleUrl'] ?? FALSE) {
-        $itemUrl = $snippet['styleUrl'];
-      }
-      elseif ($snippet['styleFile'] && count($snippet['styleFile']) == 2) {
-        $itemUrl = $res->getUrl($snippet['styleFile'][0], $snippet['styleFile'][1], TRUE);
-      }
-      if ($itemUrl) {
-        $styleUrls[] = $itemUrl;
-      }
-    }
-  }
 
   // Include our own abridged styles from jquery-ui 'smoothness' theme, as
   // required for our jquery-ui dialog, but which don't conflict with Mosaico.
@@ -121,30 +98,6 @@ Example from  [Campaign Advocacy](https://github.com/twomice/civicrm-campaignadv
 
 ```php
 function campaignadv_civicrm_mosaicoScriptUrlsAlter(&$scriptUrls) {
-  $res = CRM_Core_Resources::singleton();
-  $snippets = Civi::service('bundle.coreResources')->getAll();
-  foreach ($snippets as $snippet) {
-    $itemUrl = NULL;
-    if (
-        FALSE !== strpos($snippet['name'], 'js')
-        && !strpos($snippet['name'], 'crm.menubar.js')
-        && !strpos($snippet['name'], 'crm.menubar.min.js')
-        && !strpos($snippet['name'], 'crm.wysiwyg.js')
-        && !strpos($snippet['name'], 'crm.wysiwyg.min.js')
-        && !strpos($snippet['name'], 'l10n-js')
-      ) {
-      if ($snippet['scriptUrl'] ?? FALSE) {
-        $itemUrl = $snippet['scriptUrl'];
-      }
-      elseif ($snippet['scriptFile'] && count($snippet['scriptFile']) == 2) {
-        $itemUrl = $res->getUrl($snippet['scriptFile'][0], $snippet['scriptFile'][1], TRUE);
-      }
-      if ($itemUrl) {
-        $scriptUrls[] = $itemUrl;
-      }
-    }
-  }
-
   // Include our own JS (this url generates dynammic JS containing apprpopriate settings per session).
   $url = CRM_Utils_System::url('civicrm/campaignadv/mosaico-js', '', TRUE, NULL, NULL, NULL, NULL);
   $scriptUrls[] = $url;


### PR DESCRIPTION
Joinery has an extension [Mosaico Hooks](https://github.com/twomice/com.joineryhq.mosaicohooks) which adds some hooks to Mosaico. These hooks provide `hook_civicrm_mosaicoStyleUrlsAlter` and `hook_civicrm_mosaicoScriptUrlsAlter` to alter relevant assets in the Mosaico interface. We created this extension to prevent conflict when there are two active extension that injecting CSS and Javascript to Mosaico interface. We think it would be better if these hooks were supported by Mosaico itself.