### PR TITLE
Add hooks to alter Mosaico plugins

### DIFF
--- a/CRM/Mosaico/Page/Editor.php
+++ b/CRM/Mosaico/Page/Editor.php
@@ -14,6 +14,7 @@ class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
       $this->createMosaicoConfig(),
       defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0
     ));
+    $smarty->assign('mosaicoPlugins', $this->getMosaicoPlugins());
     echo $smarty->fetch(self::getTemplateFileName());
     CRM_Utils_System::civiExit();
   }
@@ -150,6 +151,28 @@ class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
     $iniVal = ini_get('upload_max_filesize') ? CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'), TRUE) : $fakeUnlimited;
     $settingVal = Civi::settings()->get('maxFileSize') ? (1024 * 1024 * Civi::settings()->get('maxFileSize')) : $fakeUnlimited;
     return (int) min($iniVal, $settingVal);
+  }
+
+  /**
+   * Gets the plugins for `Mosaico.init()`.
+   * 
+   * @return array
+   */
+  public function getMosaicoPlugins() {
+    $plugins = [];
+
+    // Allow plugins to be added by a hook.
+    if (class_exists('\Civi\Core\Event\GenericHookEvent')) {
+      \Civi::dispatcher()->dispatch('hook_civicrm_mosaicoPlugin',
+        \Civi\Core\Event\GenericHookEvent::create([
+          'plugins' => &$plugins,
+        ])
+      );
+    }
+
+    $plugins = '[ ' . implode(',', $plugins) . ' ]';
+
+    return $plugins;
   }
 
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -103,3 +103,34 @@ function campaignadv_civicrm_mosaicoScriptUrlsAlter(&$scriptUrls) {
   $scriptUrls[] = $url;
 }
 ```
+
+## hook_civicrm_mosaicoPlugin(&$plugins)
+
+This hook can be implemented to add custom JS plugins to the Mosaico object during initialization, see [here](https://github.com/voidlabs/mosaico/wiki/Mosaico-Plugins) on how plugins work in Mosaico.
+
+Example usage:
+```
+/**
+ * Implements hook_civicrm_mosaicoPlugin().
+ */
+function example_civicrm_mosaicoPlugin(&$plugins) {
+    $plugins[] = _example_alert_plugin();
+}
+  
+/**
+ * Example plugin to display alert on init and dispose.
+ */  
+function _example_alert_plugin(){
+    $plugin = <<< JS
+        function(vm) {
+            alert("test-plugin");
+            return {
+                    init: function(vm){alert("init");}, 
+                    dispose:  function(vm){alert("dispose");}
+                }  
+        }
+    JS;
+
+    return $plugin;
+}
+```

--- a/templates/CRM/Mosaico/Page/Editor.tpl
+++ b/templates/CRM/Mosaico/Page/Editor.tpl
@@ -23,7 +23,7 @@
         return;
       }
 
-      var plugins;
+      var plugins = {/literal}{$mosaicoPlugins}{literal};
       // A basic plugin that expose the "viewModel" object as a global variable.
       // plugins = [function(vm) {window.viewModel = vm;}];
       var config = {/literal}{$mosaicoConfig}{literal};

--- a/templates/CRM/Mosaico/Page/EditorIframe.tpl
+++ b/templates/CRM/Mosaico/Page/EditorIframe.tpl
@@ -22,7 +22,7 @@
         return;
       }
 
-      var plugins = [];
+      var plugins = {/literal}{$mosaicoPlugins}{literal};
       var config = {/literal}{$mosaicoConfig}{literal};
       
       window.addEventListener('beforeunload', function(e) {


### PR DESCRIPTION
Mosaico supports adding custom plugins to the Mosaico object during initialization as stated [here](https://github.com/voidlabs/mosaico/wiki/Mosaico-Plugins). but currently, this extension doesn't allow other extensions to add custom plugins to Mosaico during initialization as the plugins array is empty by default.

This PR adds a new hook named `hook_civicrm_mosaicoPlugin` that can be used by other modules to add plugins to the Mosaico object during initialization.

**Example usage:**
```
/**
 * Implements hook_civicrm_mosaicoPlugin().
 */
function examplemosaico_civicrm_mosaicoPlugin(&$plugins) {
    $plugins[] = _examplemosaico_alert_plugin();
}
  
/**
 * Example plugin.
 */  
function _examplemosaico_alert_plugin(){
    $plugin = <<< JS
        function(vm) {
            alert("test-plugin");
            return {
                    init: function(vm){alert("init");}, 
                    dispose:  function(vm){alert("dispose");}
                }  
        }
    JS;

    return $plugin;
}
```

The developer decides on how/where to get their JavaScript code, this is just an example.
