### PR TITLE
(#444) Auto-save after idle-timeout (~4s) and/or active-timeout (~90s)

### DIFF
--- a/ang/crmMosaico/Iframe.js
+++ b/ang/crmMosaico/Iframe.js
@@ -4,7 +4,7 @@
    * The class CrmMosaicoIframe allows you to instantiate and manage a
    * full-screen IFRAME with embedded Mosaico runtime.
    */
-  angular.module('crmMosaico').factory('CrmMosaicoIframe', function(crmUiAlert, $q, $timeout, $rootScope) {
+  angular.module('crmMosaico').factory('CrmMosaicoIframe', function(crmUiAlert, $q, $timeout, $rootScope, CrmMosaicoSyncMonitor) {
 
     /**
      * @param Object newOptions
@@ -40,6 +40,7 @@
 
       var model = cfg.model, actions = cfg.actions;
       var isVisible = false, $iframe = null, iframe = null;
+      var syncMonitor = new CrmMosaicoSyncMonitor();
 
       if (actions.save && actions.close) {
         throw "Error: Save and Close actions are mutually exclusive";
@@ -116,6 +117,7 @@
       this.hide = function hide() {
         isVisible = false;
         if ($iframe) {
+          syncMonitor.stop($iframe);
           scrollRestore();
           $iframe.hide();
         }
@@ -128,6 +130,7 @@
           scrollHide();
           onResize();
           $iframe.show();
+          syncMonitor.start($iframe);
         }
         return this;
       };
@@ -170,6 +173,10 @@
         if (actions.test) {
           viewModel.test = mkCmd("Test", actions.test);
         }
+
+        syncMonitor.onSync = function () {
+          if (actions.sync) actions.sync(ko, viewModel);
+        };
       }
 
     };

--- a/ang/crmMosaico/ListCtrl.js
+++ b/ang/crmMosaico/ListCtrl.js
@@ -30,6 +30,16 @@
       }
     });
 
+    function _saveTpl(tplId, viewModel) {
+      viewModel.metadata.changed = Date.now();
+      return crmApi('MosaicoTemplate', 'create', {
+        id: tplId,
+        html: viewModel.exportHTML(),
+        metadata: viewModel.exportMetadata(),
+        content: viewModel.exportJSON()
+      });
+    }
+
     $scope.createTpl = function createTpl(tpl) {
       return crmMosaicoPrompt(ts('Create new template'), ts('New Template (%1)', {1: tpl.type}))
         .then(function(newTitle) {
@@ -89,18 +99,14 @@
             content: fullTpl.content
           },
           actions: {
+            sync: function(ko, viewModel) {
+              var savePromise = _saveTpl(tpl.id, viewModel);
+              crmStatus({start: ts('Saving'), success: ts('Saved')}, savePromise);
+            },
             save: function(ko, viewModel) {
-              viewModel.metadata.changed = Date.now();
-
-              var savePromise = crmApi('MosaicoTemplate', 'create', {
-                id: tpl.id,
-                html: viewModel.exportHTML(),
-                metadata: viewModel.exportMetadata(),
-                content: viewModel.exportJSON()
-              }).then(function() {
+              var savePromise = _saveTpl(tpl.id, viewModel).then(function() {
                 crmMosaicoIframe.hide();
               });
-
               crmStatus({start: ts('Saving'), success: ts('Saved')}, savePromise);
             }
           }

--- a/ang/crmMosaico/MixinCtrl.js
+++ b/ang/crmMosaico/MixinCtrl.js
@@ -66,6 +66,9 @@
             content: mailing.template_options.mosaicoContent
           },
           actions: {
+            sync: function(ko, viewModel) {
+              syncModel(viewModel);
+            },
             close: function(ko, viewModel) {
               viewModel.metadata.changed = Date.now();
               syncModel(viewModel);

--- a/ang/crmMosaico/SyncMonitor.js
+++ b/ang/crmMosaico/SyncMonitor.js
@@ -1,0 +1,108 @@
+(function(angular, $, _) {
+
+  /**
+   * The class CrmMosaicoSyncMonitor monitors the Mosaico IFRAME and decides when to fire synchronization events.
+   * It follows these rules:
+   *
+   * - The user alternates between periods of being "idle" (no clicking) or "active" (clicking).
+   * - Most clicks are interpreted as activity.
+   * - Some clicks (arrow keys, home, end, mouse-scrolling) do not count as activity.
+   * - Fire `onSync()` after a (moderately) short period of idleness (eg `idleTimeout=5000`).
+   * - Fire `onSync()` after a (moderately) long period of activity (eg `activeTimeout=60000`).
+   * - Do not fire `onSync()` while there is active input (mouse-down or key-down).
+   */
+  angular.module('crmMosaico').factory('CrmMosaicoSyncMonitor', function($interval) {
+
+    // var verbose = console.log;
+    var verbose = function() {};
+
+    /**
+     * @param Object options
+     * - interval (int, ms): How frequently to poll and decide about whether to sync.
+     * - idleTimeout (int, ms): After $X period of idle usage, fire a sync.
+     * - activeTimeout (int, ms): After $X period of active usage, fire a sync.
+     * - onSync (function): The function to call periodically.
+     */
+    return function CrmMosaicoSyncMonitor(options) {
+      var defaults = {
+        interval: 500,
+        idleTimeout: 4 * 1000,
+        activeTimeout: 2 * 60 * 1000,
+        onSync: function() {}
+      };
+      angular.extend(this, defaults, options);
+
+      var monitor = this, intervalHandle = null, startCount = 0;
+      var isKeyDown, isMouseDown, lastInput, lastSync;
+
+      function ding(e) {
+        lastInput = (new Date()).getTime();
+        verbose('CrmMosaicoSyncMonitor: activity: ', lastInput, e.type);
+      }
+      function onMouseDown(e) { isMouseDown = true; ding(e); }
+      function onMouseUp(e) { isMouseDown = false; ding(e); }
+      function onKeyDown(e) { isKeyDown = true; ding(e); }
+      function onKeyUp(e) {
+        isKeyDown = false;
+        // ignore home/end/left/right/up/down keys
+        if (e.keyCode < 35 || e.keyCode > 40) {
+          ding(e);
+        }
+      }
+
+      function onPoll() {
+        if (isKeyDown || isMouseDown) {
+          verbose('CrmMosaicoSyncMonitor: onPoll: defer pending input:', isKeyDown, isMouseDown);
+          return;
+        }
+        if (lastInput === null) {
+          return;
+        }
+        var now = (new Date()).getTime();
+        if (now > lastSync + monitor.activeTimeout || now > lastInput + monitor.idleTimeout) {
+          lastSync = now;
+          lastInput = null;
+          verbose('CrmMosaicoSyncMonitor: onPoll: fire', now);
+          monitor.onSync();
+        }
+      }
+
+      this.start = function start($iframe) {
+        switch (++startCount) {
+          case 1:
+            return $iframe.load(function () {_start($iframe);});
+          default:
+            return _start($iframe);
+        }
+      };
+
+      function _start($iframe) {
+        verbose('CrmMosaicoSyncMonitor: start');
+        intervalHandle = $interval(onPoll, monitor.interval);
+
+        isKeyDown = isMouseDown = false;
+        lastInput = null;
+        lastSync = 0;
+
+        var tgt = $iframe[0].contentDocument;
+        tgt.addEventListener('mousedown', onMouseDown, true);
+        tgt.addEventListener('mouseup', onMouseUp, true);
+        tgt.addEventListener('keydown', onKeyDown, true);
+        tgt.addEventListener('keyup', onKeyUp, true);
+      }
+
+      this.stop = function stop($iframe) {
+        verbose('CrmMosaicoSyncMonitor: stop');
+        $interval.cancel(intervalHandle);
+        intervalHandle = null;
+
+        var tgt = $iframe[0].contentDocument;
+        tgt.removeEventListener('mousedown', onMouseDown, true);
+        tgt.removeEventListener('mouseup', onMouseUp, true);
+        tgt.removeEventListener('keydown', onKeyDown, true);
+        tgt.removeEventListener('keyup', onKeyUp, true);
+      };
+    };
+  });
+
+})(angular, CRM.$, CRM._);


### PR DESCRIPTION
Overview
--------------

Implement an auto-save mechanism while editing Mosaico mailings and templates. This is alternative to #471.

Background
----------------

Recall that the "New Mailing" UI is a hybrid of two JS apps, the CiviMail screen (AngularJS) and the Mosaico screen (KnockoutJS). Generally, the CiviMail side is responsible for loading/saving data - but it launches Mosaico in an IFRAME. Eventually, the Mosaico IFRAME sends data back to CiviMail.

Mosaico presents a few APIs for exchanging data. Most notably for this PR:

* `viewModel.exportMetadata()` - Get very basic info (eg the name of the base-template). This method is essentially free (<1ms on i3-10100).
* `viewModel.exportJSON()` - Get the list of blocks and styling options that the user chose. This method is essentially free (<1ms on i3-10100).
* `viewModel.exportHTML()` - Get the rendered HTML. This is composition based on the JSON data and the base-template. It is fairly expensive (200ms-300ms on i3-10100).

AFAIK, these are the only public/supported APIs for accessing the content of the editor. If you want some other API (eg incremental updates for specific blocks or text content), then that requires internal development of Mosaico/Knockout. To have maintainable interaction, we have to use these methods.

Approach
------------

Like #471, this PR updates `CrmMosaicoIframe` to support a periodic sync function, e.g.

```js
new CrmMosaicoIframe({
  actions: {
    sync: function(ko, viewModel, iframeState) {
      ...viewModel.exportJSON()...
    }
  }
})
```

Each UI ("Mailings => New Mailing" and "Mailings => Mosaico Templates") uses this sync action to call `exportJSON()`/`exportHTML()` and propagate changes.

The scheduling of the `sync` method is somewhat special:

* The `sync` method never fires while there is an active key-down or active mouse-down (deferring until the key is released).
* The `sync` method fires after ~4s of idleness.
* Alternatively, the `sync` method fires after ~90s of near-continuous activity.

Limitations
-------------------------

__Active TinyMCE__: Mosaico does not update its internal model while a user is focused on a rich text box -- it updates when the user moves away from the textbox. Consequently, the autosave/sync/export processes do not have immediate visibility into pending changes in a paragraph. Autosave should still be useful in typical usage-patterns. [More discussion of this limitation](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/pull/471#issuecomment-948251124).

__JS Console Warning__: When saving, it may sometimes generate a warning. I haven't found any particular breakage from it, but I can't decisively say whether it is safe or unsafe.

```
TODO exception scrolling into view TypeError: e is null
```

