### PR TITLE
Send test

### DIFF
--- a/ang/crmMosaico.crmstar/BlockPreview.html
+++ b/ang/crmMosaico.crmstar/BlockPreview.html
@@ -11,12 +11,12 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
     </div>
     <div ng-hide="!mailing.body_html">
       <div>
-        <button class="btn btn-primary" ng-disabled="crmMailing.$invalid" ng-click="doPreview('html')">{{:: ts('Preview as HTML') }}</button>
+        <button class="btn btn-primary full-width-force" ng-disabled="crmMailing.$invalid" ng-click="doPreview('html')">{{:: ts('Preview as HTML') }}</button>
       </div>
     </div>
     <div ng-hide="!mailing.body_html && !mailing.body_text" style="margin-top: 1em;">
       <div>
-        <button class="btn btn-primary" ng-disabled="crmMailing.$invalid" ng-click="doPreview('text')">{{:: ts('Preview as Plain Text') }}</button>
+        <button class="btn btn-primary full-width-force" ng-disabled="crmMailing.$invalid" ng-click="doPreview('text')">{{:: ts('Preview as Plain Text') }}</button>
       </div>
     </div>
   </div>
@@ -32,7 +32,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
       ng-model="testContact.email"
       placeholder="example@example.org" />
     <!--fa-paper-plane-->
-    <button class="btn btn-sm btn-primary" title="{{crmMailing.$invalid || !testContact.email ? ts('Complete all required-mark fields first') : ts('Send test message to %1', {1: testContact.email})}}" ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})">
+    <button class="btn btn-sm btn-primary full-width-force" title="{{crmMailing.$invalid || !testContact.email ? ts('Complete all required-mark fields first') : ts('Send test message to %1', {1: testContact.email})}}" ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})">
       {{:: ts('Send test') }}
     </button>
   </div>
@@ -50,7 +50,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
       class="margin-bottom-10 full-width-force"
     >
     <!--fa-paper-plane-->
-    <button class="btn btn-sm btn-primary" title="{{crmMailing.$invalid || !testGroup.gid ? ts('Complete all required-mark fields first') : ts('Send test message to group')}}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}"
+    <button class="btn btn-sm btn-primary full-width-force" title="{{crmMailing.$invalid || !testGroup.gid ? ts('Complete all required-mark fields first') : ts('Send test message to group')}}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}"
        on-yes="doSend({gid: testGroup.gid})">{{:: ts('Send test') }}</button>
   </div>
 </div>

--- a/ang/crmMosaico.crmstar/BlockPreview.html
+++ b/ang/crmMosaico.crmstar/BlockPreview.html
@@ -11,12 +11,12 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
     </div>
     <div ng-hide="!mailing.body_html">
       <div>
-        <button class="btn btn-primary full-width-force" ng-disabled="crmMailing.$invalid" ng-click="doPreview('html')">{{:: ts('Preview as HTML') }}</button>
+        <button class="btn btn-primary full-width-force" type="button" ng-disabled="crmMailing.$invalid" ng-click="doPreview('html')">{{:: ts('Preview as HTML') }}</button>
       </div>
     </div>
     <div ng-hide="!mailing.body_html && !mailing.body_text" style="margin-top: 1em;">
       <div>
-        <button class="btn btn-primary full-width-force" ng-disabled="crmMailing.$invalid" ng-click="doPreview('text')">{{:: ts('Preview as Plain Text') }}</button>
+        <button class="btn btn-primary full-width-force" type="button" ng-disabled="crmMailing.$invalid" ng-click="doPreview('text')">{{:: ts('Preview as Plain Text') }}</button>
       </div>
     </div>
   </div>
@@ -32,7 +32,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
       ng-model="testContact.email"
       placeholder="example@example.org" />
     <!--fa-paper-plane-->
-    <button class="btn btn-sm btn-primary full-width-force" title="{{crmMailing.$invalid || !testContact.email ? ts('Complete all required-mark fields first') : ts('Send test message to %1', {1: testContact.email})}}" ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})">
+    <button class="btn btn-sm btn-primary full-width-force" type="button" title="{{crmMailing.$invalid || !testContact.email ? ts('Complete all required-mark fields first') : ts('Send test message to %1', {1: testContact.email})}}" ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})">
       {{:: ts('Send test') }}
     </button>
   </div>
@@ -50,7 +50,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
       class="margin-bottom-10 full-width-force"
     >
     <!--fa-paper-plane-->
-    <button class="btn btn-sm btn-primary full-width-force" title="{{crmMailing.$invalid || !testGroup.gid ? ts('Complete all required-mark fields first') : ts('Send test message to group')}}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}"
+    <button class="btn btn-sm btn-primary full-width-force" type="button" title="{{crmMailing.$invalid || !testGroup.gid ? ts('Complete all required-mark fields first') : ts('Send test message to group')}}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}"
        on-yes="doSend({gid: testGroup.gid})">{{:: ts('Send test') }}</button>
   </div>
 </div>

--- a/ang/crmMosaico.crmstar/BlockPreview.html
+++ b/ang/crmMosaico.crmstar/BlockPreview.html
@@ -11,12 +11,12 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
     </div>
     <div ng-hide="!mailing.body_html">
       <div>
-        <a class="btn btn-primary" ng-disabled="crmMailing.$invalid" ng-click="doPreview('html')">{{:: ts('Preview as HTML') }}</a>
+        <button class="btn btn-primary" ng-disabled="crmMailing.$invalid" ng-click="doPreview('html')">{{:: ts('Preview as HTML') }}</button>
       </div>
     </div>
     <div ng-hide="!mailing.body_html && !mailing.body_text" style="margin-top: 1em;">
       <div>
-        <a class="btn btn-primary" ng-disabled="crmMailing.$invalid" ng-click="doPreview('text')">{{:: ts('Preview as Plain Text') }}</a>
+        <button class="btn btn-primary" ng-disabled="crmMailing.$invalid" ng-click="doPreview('text')">{{:: ts('Preview as Plain Text') }}</button>
       </div>
     </div>
   </div>
@@ -32,9 +32,9 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
       ng-model="testContact.email"
       placeholder="example@example.org" />
     <!--fa-paper-plane-->
-    <a class="btn btn-sm btn-primary" title="{{crmMailing.$invalid || !testContact.email ? ts('Complete all required-mark fields first') : ts('Send test message to %1', {1: testContact.email})}}" ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})">
+    <button class="btn btn-sm btn-primary" title="{{crmMailing.$invalid || !testContact.email ? ts('Complete all required-mark fields first') : ts('Send test message to %1', {1: testContact.email})}}" ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})">
       {{:: ts('Send test') }}
-    </a>
+    </button>
   </div>
 
   <div class="form-group">
@@ -50,7 +50,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
       class="margin-bottom-10 full-width-force"
     >
     <!--fa-paper-plane-->
-    <a class="btn btn-sm btn-primary" title="{{crmMailing.$invalid || !testGroup.gid ? ts('Complete all required-mark fields first') : ts('Send test message to group')}}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}"
-       on-yes="doSend({gid: testGroup.gid})">{{:: ts('Send test') }}</a>
+    <button class="btn btn-sm btn-primary" title="{{crmMailing.$invalid || !testGroup.gid ? ts('Complete all required-mark fields first') : ts('Send test message to group')}}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}"
+       on-yes="doSend({gid: testGroup.gid})">{{:: ts('Send test') }}</button>
   </div>
 </div>


### PR DESCRIPTION
fix #449 

**Before**
After debugging I found that in [`BlockPreview.js`](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/blob/9ff7a27fdfb2ebecd77294a287a1ed057d9cedd8/ang/crmMosaico/BlockPreview.js#L33) if there is no group id supplied, it will list all contacts.

Then I realized this button shouldn't be enabled in the first place when there is no group selected. [`BlockPreview.html`](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/blob/e95d72b03c2896004576f2b11e9be56e30370d0b/ang/crmMosaico.crmstar/BlockPreview.html#L52)

As I see these buttons are an `<a>` element in `ang/crmMosaico.crmstar/BlockPreview.html` for which the `"disabled"` attribute is not defined.

**After**
I changed them to `<button>` elements (as in `ang/crmMosaico.bootstrap/BlockPreview.html`) and it has the desired functionality, however full width was forced for these elements to have the same look as the `<a>` elements.