### PR TITLE
Multisite support for mosaico

### DIFF
--- a/CRM/Mosaico/Page/Editor.php
+++ b/CRM/Mosaico/Page/Editor.php
@@ -65,7 +65,8 @@ class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
     ]);
 
     $config = [
-      'imgProcessorBackend' => $this->getUrl('civicrm/mosaico/img', NULL, TRUE),
+      // Changed the frontEnd param as FALSE
+      'imgProcessorBackend' => $this->getUrl('civicrm/mosaico/img', NULL, FALSE),
       'imgPlaceholderUrl' => $this->getUrl('civicrm/mosaico/img/placeholder', NULL, FALSE),
       'emailProcessorBackend' => 'unused-emailProcessorBackend',
       'titleToken' => 'MOSAICO Responsive Email Designer',

--- a/CRM/Mosaico/Upgrader.php
+++ b/CRM/Mosaico/Upgrader.php
@@ -125,6 +125,27 @@ class CRM_Mosaico_Upgrader extends CRM_Mosaico_Upgrader_Base {
   }
 
   /**
+   * Add domain_id to the civicrm_mosaico_template table.
+   */
+  public function upgrade_4705() {
+    $this->ctx->log->info('Applying update 4705');
+
+    CRM_Core_DAO::executeQuery('
+      ALTER TABLE civicrm_mosaico_template
+      ADD COLUMN `domain_id` int unsigned NULL COMMENT \'FK from civicrm_domain.\'
+    ');
+
+    CRM_Core_DAO::executeQuery('
+      ALTER TABLE civicrm_mosaico_template
+      ADD CONSTRAINT FK_civicrm_mosaico_template_domain_id
+      FOREIGN KEY (`domain_id`) REFERENCES `civicrm_domain`(`id`)
+      ON DELETE SET NULL
+    ');
+
+    return TRUE;
+  }
+
+  /**
    * Example: Run an external SQL script.
    *
    * @return TRUE on success

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,3 +61,7 @@ If you move CiviCRM to a new domain, you must update the template paths using th
 ```
 cv api MosaicoTemplate.replaceurls from_url="http://old.server.org" to_url="https://new.server.org"
 ```
+
+## Multisite Support - Restrict image gallery to each domain
+- You need to ensure that you have separate images directory in each multisite, so that each site would have unique set of images in their gallery while editing a template.
+- You can set images directory in Administer >> System Settings >> Directories.

--- a/sql/auto_install.sql
+++ b/sql/auto_install.sql
@@ -79,12 +79,14 @@ CREATE TABLE `civicrm_mosaico_template` (
      `html` longtext    COMMENT 'Fully renderd HTML',
      `metadata` longtext    COMMENT 'Mosaico metadata (JSON)',
      `content` longtext    COMMENT 'Mosaico content (JSON)',
-     `msg_tpl_id` int unsigned NULL   COMMENT 'FK to civicrm_msg_template.' 
+     `msg_tpl_id` int unsigned NULL   COMMENT 'FK to civicrm_msg_template.',
+     `domain_id` int unsigned NULL   COMMENT 'FK to civicrm_domain.'
 ,
         PRIMARY KEY (`id`)
- 
- 
-,          CONSTRAINT FK_civicrm_mosaico_template_msg_tpl_id FOREIGN KEY (`msg_tpl_id`) REFERENCES `civicrm_msg_template`(`id`) ON DELETE SET NULL  
-) ENGINE=InnoDB    ;
+
+
+,          CONSTRAINT FK_civicrm_mosaico_template_msg_tpl_id FOREIGN KEY (`msg_tpl_id`) REFERENCES `civicrm_msg_template`(`id`) ON DELETE SET NULL
+,          CONSTRAINT FK_civicrm_mosaico_template_domain_id FOREIGN KEY (`domain_id`) REFERENCES `civicrm_domain`(`id`) ON DELETE SET NULL
+) ENGINE=InnoDB     ;
 
  


### PR DESCRIPTION
- Add domain_id to civicrm_mosaico_template table
- Save domain_id during new template creation
- Display templates specific to the domain in view all templates page
- Updated docs on how to setup upload directory when using multisite setup, to restrict gallery to each domain

Issues addressed:
https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/issues/410
https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/issues/438