### PR TITLE
Cleanup BlockPreview.html (again)

### DIFF
--- a/ang/crmMosaico.bootstrap/BlockPreview.html
+++ b/ang/crmMosaico.bootstrap/BlockPreview.html
@@ -2,42 +2,45 @@
 Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
 -->
 <div class="form-group">
-  <label>{{ts('Preview:')}}</label>
+  <label>{{:: ts('Preview:') }}</label>
   <div ng-show="!mailing.body_html && !mailing.body_text">
-    <em>({{ts('No content to preview')}})</em>
+    <em>({{:: ts('No content to preview') }})</em>
   </div>
   <div ng-hide="!mailing.body_html" class="btn-group btn-group-justified">
     <div class="btn-group">
-      <button class="btn btn-primary" ng-disabled="crmMailing.$invalid" ng-click="doPreview('html')">{{ts('Preview as HTML')}}</button>
+      <button type="button" class="btn btn-primary" ng-disabled="crmMailing.$invalid" ng-click="doPreview('html')">{{:: ts('Preview as HTML') }}</button>
     </div>
   </div>
   <div ng-hide="!mailing.body_html && !mailing.body_text" style="margin-top: 1em;" class="btn-group btn-group-justified">
     <div class="btn-group">
-      <button class="btn btn-primary" ng-disabled="crmMailing.$invalid" ng-click="doPreview('text')">{{ts('Preview as Plain Text')}}</button>
+      <button type="button" class="btn btn-primary" ng-disabled="crmMailing.$invalid" ng-click="doPreview('text')">{{:: ts('Preview as Plain Text') }}</button>
     </div>
   </div>
 </div>
 
 <div class="form-group">
-  <label for="preview_test_email">{{ts('Send test email:')}} <a crm-ui-help="hs({id: 'test', title: ts('Test Email')})"></a> </label>
+  <label for="preview_test_email">{{:: ts('Send test email:') }} <a crm-ui-help="hs({id: 'test', title: ts('Test Email')})"></a> </label>
   <input
-    name="preview_test_email"
+    id="preview_test_email"
     type="email"
     class="form-control margin-bottom-10"
     ng-model="testContact.email"
     placeholder="example@example.org" />
   <!--fa-paper-plane-->
-  <button class="btn btn-sm btn-primary" title="{{crmMailing.$invalid || !testContact.email ? ts('Complete all required-mark fields first') : ts('Send test message to %1', {1: testContact.email})}}" ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})">{{ts('Send test')}}</button>
+  <button type="button" class="btn btn-sm btn-primary" title="{{ crmMailing.$invalid || !testContact.email ? ts('Complete all required-mark fields first') : ts('Send test message to %1', {1: testContact.email}) }}" ng-disabled="crmMailing.$invalid || !testContact.email" ng-click="doSend({email: testContact.email})">
+    {{:: ts('Send test') }}
+  </button>
 </div>
 
 <div class="form-group">
-  <label for="preview_test_group">{{ts('Send test email to group:')}} <a crm-ui-help="hs({id: 'test', title: ts('Test Email')})"></a> </label>
+  <label for="preview_test_group">{{:: ts('Send test email to group:') }} <a crm-ui-help="hs({id: 'test', title: ts('Test Email')})"></a> </label>
   <input
+    id="preview_test_group"
     crm-entityref="{entity: 'Group', api: {params: {is_hidden: 0, is_active: 1}}, select: {allowClear:true, minimumInputLength: 0}}"
     ng-model="testGroup.gid"
     class="form-control margin-bottom-10 full-width-force"
   />
   <!--fa-paper-plane-->
-  <button class="btn btn-sm btn-primary" title="{{crmMailing.$invalid || !testGroup.gid ? ts('Complete all required-mark fields first') : ts('Send test message to group')}}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}"
-      on-yes="doSend({gid: testGroup.gid})">{{ts('Send test')}}</button>
+  <button type="button" class="btn btn-sm btn-primary" title="{{ crmMailing.$invalid || !testGroup.gid ? ts('Complete all required-mark fields first') : ts('Send test message to group') }}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}"
+      on-yes="doSend({gid: testGroup.gid})">{{:: ts('Send test') }}</button>
 </div>


### PR DESCRIPTION
Same as #481 but for the evil twin of the same file.

- Use one-time binding for static strings in ts()
- Add type="button" to button elements
- Make sure labels and form elements match

Same damn cleanup, different damn file. In case I haven't told enough people, I really hate the fact that there are two of every template file in this extension, and I can't wait to get rid of the duplicates.