### PR TITLE
Include Civi and managed directories in zip file

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -125,7 +125,7 @@ function do_zipfile() {
        ## Get any files in the project root, except for dotfiles.
        find . -mindepth 1 -maxdepth 1 -type f -o -type d | grep -v '^\./\.'
        ## Get any files in the main subfolders.
-       find CRM/ ang/ api/ bin/ css/ js/ sql/ sass/ settings/ templates/ tests/ vendor/ xml/ -type f -o -type d
+       find CRM/ Civi/ ang/ api/ bin/ css/ js/ managed/ sql/ sass/ settings/ templates/ tests/ vendor/ xml/ -type f -o -type d
        ## Get the distributable files for Mosaico.
        find packages/mosaico/{NOTICE,README,LICENSE,dist,templates}* -type f -o -type d
     } \


### PR DESCRIPTION
Overview
--------------
Fixes missing directories in packaged file.

Comments
-----------
This includes all the necessary directories now... but one question: why is `tests/` included as part of the zip file? That strikes me as odd.