### PR TITLE
Add validation rule to Mosaico uploader

### DIFF
--- a/templates/CRM/Mosaico/Page/EditorIframe.tpl
+++ b/templates/CRM/Mosaico/Page/EditorIframe.tpl
@@ -24,7 +24,7 @@
 
       var plugins = {/literal}{$mosaicoPlugins}{literal};
       var config = {/literal}{$mosaicoConfig}{literal};
-      
+
       window.addEventListener('beforeunload', function(e) {
         if(window.parent.document.getElementById('crm-mosaico').style.display !== "none") {
           e.preventDefault();
@@ -32,6 +32,9 @@
         }
       });
 
+      if (config.fileuploadConfig.acceptFileTypes) {
+        config.fileuploadConfig.acceptFileTypes = /(\.|\/)(|gif|p?jpe?g|png|x-png)$/i;
+      }
       if (window.top.crmMosaicoIframe) {
         window.top.crmMosaicoIframe(window, Mosaico, config, plugins);
       }


### PR DESCRIPTION
I tried do it a generic way, like fetch a mutual list of allowed file types from civi's safe_file_extensions option group and mosaico internal library but there seems to be few limitations on doing so. So I went with harcoded file extension which are allowed image ext in both mosaico and civicrm   