### PR TITLE
Mosaico: loosen restrictions on required fields

### DIFF
--- a/ang/crmMosaico/BlockMailing.html
+++ b/ang/crmMosaico/BlockMailing.html
@@ -1,9 +1,9 @@
 <div ng-form="subform" crm-ui-id-scope>
 
   <div class="form-group-lg">
-    <label for="inputTitle" class="control-label required-mark">{{ts('Mailing Name')}}
+    <label for="inputTitle" ng-class="checkPerm('create mailings') ? 'control-label' : 'control-label required-mark'">{{ts('Mailing Name')}}
       <a crm-ui-help="hs({id: 'name', title: ts('Mailing Name')})"></a></label>
-    <input type="text" class="form-control" id="inputTitle" placeholder="{{ts('Mailing Name')}}" ng-model="mailing.name" required>
+    <input type="text" class="form-control" id="inputTitle" placeholder="{{ts('Mailing Name')}}" ng-model="mailing.name" ng-required="!checkPerm('create mailings')">
   </div>
 
   <div class="form-group" ng-show="crmMailingConst.campaignEnabled">
@@ -19,7 +19,7 @@
   </div>
 
   <div class="form-group">
-    <label for="inputFrom" class="control-label required-mark">{{ts('From')}}
+    <label for="inputFrom" ng-class="checkPerm('create mailings') ? 'control-label' : 'control-label required-mark'">{{ts('From')}}
       <a crm-ui-help="hs({id: 'from_email', title: ts('From')})"></a></label>
     <div ng-controller="EmailAddrCtrl" crm-mailing-from-address="fromPlaceholder" crm-mailing="mailing">
       <select
@@ -54,12 +54,12 @@
   </div>
 
   <div class="form-group">
-    <label for="inputRecipients" class="control-label required-mark">{{ts('Recipients')}}</label>
+    <label for="inputRecipients" ng-class="checkPerm('create mailings') ? 'control-label' : 'control-label required-mark'">{{ts('Recipients')}}</label>
     <div crm-mailing-block-recipients="{name: 'recipients', id: 'subform.recipients'}" crm-mailing="mailing"></div>
   </div>
 
   <div class="form-group">
-    <label for="inputSubject" class="control-label required-mark">{{ts('Subject')}}</label>
+    <label for="inputSubject" ng-class="checkPerm('create mailings') ? 'control-label' : 'control-label required-mark'">{{ts('Subject')}}</label>
     <div>
       <crm-mosaico-subject-list crm-mailing="mailing" />
     </div>
@@ -85,7 +85,7 @@
   </span>
 
   <div class="form-group" ng-if="crmMailingConst.isMultiLingual">
-    <label for="inputLanguage" class="control-label required-mark">{{ts('Language')}}</label>
+    <label for="inputLanguage" ng-class="checkPerm('create mailings') ? 'control-label' : 'control-label required-mark'">{{ts('Language')}}</label>
     <select
         id="inputLanguage"
         name="language"

--- a/ang/crmMosaico/SubjectList.js
+++ b/ang/crmMosaico/SubjectList.js
@@ -12,6 +12,7 @@
         });
         scope.ts = CRM.ts(null);
         scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
+        scope.checkPerm = CRM.checkPerm;
 
         scope.addSubj = function addSubj() {
           scope.mailing.template_options.variants = [


### PR DESCRIPTION
Currently, when building a mailing, you must complete all required fields on the first step of the wizard before you can advance to the builder step. It's not uncommon for one person to be tasked with building out the content for an email, and someone else be responsible for building the recipient list. But those first-step requirements create a problem if the first person to create the email is the content builder. With the traditional builder, you can work on the content as soon as you create the email, and can save it without filling in other required fields. The required fields are only necessary in order to advance to the scheduling step. This patch is to make Mosaico work in similar way 