### PR TITLE
Don't add the "schedule/send via CiviMail" search task, if the user has insufficient permissions

### DIFF
--- a/mosaico.php
+++ b/mosaico.php
@@ -406,10 +406,12 @@ function mosaico_civicrm_container(\Symfony\Component\DependencyInjection\Contai
  */
 function mosaico_civicrm_searchTasks($objectName, &$tasks) {
   if ($objectName == 'contact') {
-    $tasks[] = [
-      'title' => E::ts('Email - schedule/send via CiviMail (traditional)'),
-      'class' => 'CRM_Mosaico_Form_Task_AdhocMailingTraditional',
-    ];
+    if (CRM_Core_Permission::access('CiviMail')) {
+      $tasks[] = [
+          'title' => E::ts('Email - schedule/send via CiviMail (traditional)'),
+          'class' => 'CRM_Mosaico_Form_Task_AdhocMailingTraditional',
+      ];
+    }
   }
 }
 


### PR DESCRIPTION
The "schedule/send via CiviMail" search task is currently *always* added, however the subsequent action requires the CiviMailing permissions.

With this PR the search task would only be injected if the ``access CiviMail`` permission is granted for the current user.

See also #483