### PR TITLE
Default orderBy Title on template listing search display

### DIFF
--- a/managed/Mosaico_Template_Listing.mgd.php
+++ b/managed/Mosaico_Template_Listing.mgd.php
@@ -56,7 +56,12 @@ return [
             'show_count' => TRUE,
             'expose_limit' => TRUE,
           ],
-          'sort' => [],
+          'sort' => [
+            [
+              'title',
+              'ASC',
+            ],
+          ],
           'columns' => [
             [
               'type' => 'field',


### PR DESCRIPTION
When visiting the "Mosaico Templates" listing, they will now be initially sorted alphabetically by title. Previously there was no default order.

![image](https://user-images.githubusercontent.com/2874912/157720976-12e40b4a-9ea6-4547-9904-2e32b2d0ee86.png)
