### PR TITLE
Fix crash when installing via CLI

### DIFF
--- a/CRM/Mosaico/Upgrader.php
+++ b/CRM/Mosaico/Upgrader.php
@@ -21,7 +21,7 @@ class CRM_Mosaico_Upgrader extends CRM_Mosaico_Upgrader_Base {
       ->setMatch(['name'])
       ->execute();
 
-    $existingCategories = \Civi\Api4\OptionValue::get()
+    $existingCategories = \Civi\Api4\OptionValue::get(FALSE)
       ->selectRowCount()
       ->addWhere('option_group_id.name', '=', 'mailing_template_category')
       ->execute();


### PR DESCRIPTION
This fixes a crash when installing the `2.x` HEAD via CLI.

```
Enabling extension "uk.co.vedaconsulting.mosaico"
Error: API Call Failed: Array
(
    [entity] => Extension
    [action] => install
    [params] => Array
        (
            [keys] => Array
                (
                    [0] => uk.co.vedaconsulting.mosaico
                )

            [debug] => 1
            [version] => 3
        )

    [result] => Array
        (
            [error_code] => unauthorized
            [entity] => Extension
            [action] => install
            [trace] => #0 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Kernel.php(147): Civi\API\Kernel->authorize(Object(Civi\Api4\Provider\ActionObjectProvider), Object(Civi\Api4\Generic\DAOGetAction))
#1 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/Api4/Generic/AbstractAction.php(234): Civi\API\Kernel->runRequest(Object(Civi\Api4\Generic\DAOGetAction))
#2 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/ext/mosaico/CRM/Mosaico/Upgrader.php(27): Civi\Api4\Generic\AbstractAction->execute()
#3 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/ext/mosaico/CRM/Mosaico/Upgrader/Base.php(326): CRM_Mosaico_Upgrader->install()
#4 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/ext/mosaico/mosaico.civix.php(131): CRM_Mosaico_Upgrader_Base->onInstall()
#5 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/ext/mosaico/mosaico.php(30): _mosaico_civix_civicrm_install()
#6 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Extension/Manager/Module.php(61): mosaico_civicrm_install()
#7 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Extension/Manager/Module.php(33): CRM_Extension_Manager_Module->callHook(Object(CRM_Extension_Info), 'install')
#8 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/CRM/Extension/Manager.php(293): CRM_Extension_Manager_Module->onPreInstall(Object(CRM_Extension_Info))
#9 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/api/v3/Extension.php(42): CRM_Extension_Manager->install(Array)
#10 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Provider/MagicFunctionProvider.php(89): civicrm_api3_extension_install(Array)
#11 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Kernel.php(149): Civi\API\Provider\MagicFunctionProvider->invoke(Array)
#12 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/Civi/API/Kernel.php(81): Civi\API\Kernel->runRequest(Array)
#13 /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/api/api.php(22): Civi\API\Kernel->runSafe('Extension', 'install', Array)
#14 phar:///Users/totten/bknix/bin/cv/src/Command/BaseCommand.php(63): civicrm_api('Extension', 'install', Array)
#15 phar:///Users/totten/bknix/bin/cv/src/Command/ExtensionEnableCommand.php(91): Civi\Cv\Command\BaseCommand->callApiSuccess(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput), 'Extension', 'install', Array)
#16 phar:///Users/totten/bknix/bin/cv/vendor/symfony/console/Command/Command.php(255): Civi\Cv\Command\ExtensionEnableCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 phar:///Users/totten/bknix/bin/cv/vendor/symfony/console/Application.php(1009): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#18 phar:///Users/totten/bknix/bin/cv/vendor/symfony/console/Application.php(273): Symfony\Component\Console\Application->doRunCommand(Object(Civi\Cv\Command\ExtensionEnableCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#19 phar:///Users/totten/bknix/bin/cv/src/Application.php(59): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#20 phar:///Users/totten/bknix/bin/cv/vendor/symfony/console/Application.php(149): Civi\Cv\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#21 phar:///Users/totten/bknix/bin/cv/src/Application.php(26): Symfony\Component\Console\Application->run()
#22 phar:///Users/totten/bknix/bin/cv/bin/cv(27): Civi\Cv\Application::main('phar:///Users/t...')
#23 /Users/totten/bknix/bin/cv(14): require('phar:///Users/t...')
#24 {main}
            [is_error] => 1
            [error_message] => Authorization failed
        )

)
```

The problem does not affect the last tagged release (`2.9`); it's a regression within the dev branch (c6cf25827d199186328919a9e42804033deefa6b).
