### PR TITLE
Download Mosaico JS files via composer-downloads-plugin

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-DEFAULT_MOSAICO_BRANCH="v0.15-civicrm-2"
-DEFAULT_MOSAICO_REPO="https://github.com/civicrm/mosaico"
 EXTROOT=$(cd `dirname $0`/..; pwd)
 EXTKEY="uk.co.vedaconsulting.mosaico"
 XMLBUILD="$EXTROOT/build/xml/schema"
@@ -83,24 +81,6 @@ function do_gencode() {
 
 ##############################
 function do_download() {
-  if [ ! -d "$EXTROOT/packages" ]; then
-    mkdir "$EXTROOT/packages"
-  fi
-  if [ ! -d "$EXTROOT/packages/mosaico" ]; then
-    git clone -b "$DEFAULT_MOSAICO_BRANCH" "$DEFAULT_MOSAICO_REPO" "$EXTROOT/packages/mosaico"
-  fi
-  pushd "$EXTROOT/packages/mosaico" >> /dev/null
-    local currentBranch=$(basename /$(git symbolic-ref HEAD 2>/dev/null))
-    if [ "$currentBranch" != "$DEFAULT_MOSAICO_BRANCH" ]; then
-      echo "Error: packages/mosaico is not on expected branch ($DEFAULT_MOSAICO_BRANCH). You may either:"
-      echo " (1) Checkout the branch '$DEFAULT_MOSAICO_BRANCH'. Then run 'setup.sh -D' again."
-      echo " (2) Manage the branch manualy. Be sure to call 'npm install' and 'grunt' as needed."
-      exit 1
-    fi
-    npm install
-    find node_modules -name '*.info' -delete
-    grunt build
-  popd >> /dev/null
   pushd "$EXTROOT" >> /dev/null
     composer install
   popd >> /dev/null

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,25 @@
 {
+  "name": "civipkg/uk.co.vedaconsulting.mosaico",
   "require": {
-    "intervention/image": "^2.4"
+    "intervention/image": "^2.4",
+    "civicrm/composer-downloads-plugin": "^3.0"
   },
   "replace": {
     "guzzlehttp/guzzle": "^6.5",
     "guzzlehttp/psr7": "^1.8.5"
+  },
+  "config": {
+    "allow-plugins": {
+      "civicrm/composer-downloads-plugin": true
+    }
+  },
+  "extra": {
+    "downloads": {
+      "mosaico": {
+        "version": "v0.15-civicrm-2.1",
+        "path": "packages/mosaico",
+        "url": "https://github.com/civicrm/mosaico/releases/download/{$version}/mosaico-dist.tar.gz"
+      }
+    }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,62 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a911f0c567ab4d8fa83564f926e7dae8",
+    "content-hash": "853acfa3a721622f20c92a18f7788ff2",
     "packages": [
+        {
+            "name": "civicrm/composer-downloads-plugin",
+            "version": "v3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/civicrm/composer-downloads-plugin.git",
+                "reference": "3aabb6d259a86158d01829fc2c62a2afb9618877"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/civicrm/composer-downloads-plugin/zipball/3aabb6d259a86158d01829fc2c62a2afb9618877",
+                "reference": "3aabb6d259a86158d01829fc2c62a2afb9618877",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "php": ">=5.6",
+                "togos/gitignore": "~1.1.1"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "phpunit/phpunit": "^5.7",
+                "totten/process-helper": "^1.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "LastCall\\DownloadsPlugin\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "LastCall\\DownloadsPlugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Bayliss",
+                    "email": "rob@lastcallmedia.com"
+                },
+                {
+                    "name": "Tim Otten",
+                    "email": "totten@civicrm.org"
+                }
+            ],
+            "description": "Composer plugin for downloading additional files within any composer package.",
+            "support": {
+                "source": "https://github.com/civicrm/composer-downloads-plugin/tree/v3.0.1"
+            },
+            "time": "2020-11-02T05:26:23+00:00"
+        },
         {
             "name": "intervention/image",
             "version": "2.7.1",
@@ -89,6 +143,43 @@
                 }
             ],
             "time": "2021-12-16T16:49:26+00:00"
+        },
+        {
+            "name": "togos/gitignore",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TOGoS/PHPGitIgnore.git",
+                "reference": "32bc0830e4123f670adcbf5ddda5bef362f4f4d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TOGoS/PHPGitIgnore/zipball/32bc0830e4123f670adcbf5ddda5bef362f4f4d4",
+                "reference": "32bc0830e4123f670adcbf5ddda5bef362f4f4d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "togos/simpler-test": "1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "TOGoS_GitIgnore_": "src/main/php/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Parser for .gitignore (and sparse-checkout, and anything else using the same format) files",
+            "support": {
+                "issues": "https://github.com/TOGoS/PHPGitIgnore/issues",
+                "source": "https://github.com/TOGoS/PHPGitIgnore/tree/master"
+            },
+            "time": "2019-04-19T19:16:58+00:00"
         }
     ],
     "packages-dev": [],
@@ -99,5 +190,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
This should lighten the load on downloading from git (and also resolve #479).

* __Before__: Clone the main Mosaico repo. Run a full JS toolchain (`npm`, `node`, `bower`, `grunt`, `phantom`) to create the compiled Mosaico JS.
* __After__: Download pre-compiled Mosaico JS.

