### PR TITLE
Pass in String null so that db field is set to NULL

### DIFF
--- a/mosaico.php
+++ b/mosaico.php
@@ -338,8 +338,8 @@ function mosaico_civicrm_entityTypes(&$entityTypes) {
 function mosaico_civicrm_pre($op, $objectName, $id, &$params) {
   if ($objectName === 'Mailing' && $op === 'create') {
     if (isset($params['template_type']) && $params['template_type'] === 'mosaico') {
-      $params['header_id'] = NULL;
-      $params['footer_id'] = NULL;
+      $params['header_id'] = 'null';
+      $params['footer_id'] = 'null';
     }
   }
 }


### PR DESCRIPTION
As per this line https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/DAO.php#L786 I think this is a better fix to ensure that NULL values are stored in the table for these fields @mattwire 