### PR TITLE
Fix issue where by some large placeholders aren't rendering behind ap…

### DIFF
--- a/CRM/Mosaico/Graphics/Intervention.php
+++ b/CRM/Mosaico/Graphics/Intervention.php
@@ -74,8 +74,9 @@ class CRM_Mosaico_Graphics_Intervention extends CRM_Mosaico_Graphics_Interface {
 
     // $img->response returns a \Symfony\Component\HttpFoundation\Response object which will call __toString unless we pass in the send() method in Drupal8.
     $response = $img->response('png');
+    header("Content-type: image/png");
     if (is_object($response)) {
-      echo $response->send();
+      echo $response->sendContent();
     }
     else {
       echo $response;


### PR DESCRIPTION
…plication load balancers

For one of our clients we had an issue where it seems like the size of the headers being returned by send() was too large for the application load balancer, I found that this fixed things for the client site which was a D9 site