### PR TITLE
Fix issue with urls that are double url encoded

### DIFF
--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -387,7 +387,7 @@ class CRM_Mosaico_Utils {
       case 'cover':
         $func = ($method === 'resize') ? 'createResizedImage' : 'createCoveredImage';
 
-        $path_parts = pathinfo(CRM_Utils_String::purifyHTML(CRM_Utils_Request::retrieveValue('src', 'String', NULL, TRUE, 'GET')));
+        $path_parts = pathinfo(CRM_Utils_String::purifyHTML(urldecode(str_replace('%25', '%', CRM_Utils_Request::retrieveValue('src', 'String', NULL, TRUE, 'GET')))));
         $src_file = $config['BASE_DIR'] . $config['UPLOADS_DIR'] . $path_parts["basename"];
         $cache_file = $config['BASE_DIR'] . $config['STATIC_DIR'] . $path_parts["basename"];
         // $cache_file = $config['BASE_DIR'] . $config['STATIC_DIR'] . $method . '-' . $width . "x" . $height . '-' . $path_parts["basename"];


### PR DESCRIPTION
We found that for some of our sites we were having situations were we would get errors about Failed to locate source file `https%3A%2F%2F<client site domain>%2Fsites%2Fdefault%2Ffiles%2Fcivicrm%2Fpersist%2Fcontribute%2Fimages%2Fuploads%2F<filename>.jpg` 

We found that applying this patch improved things

the request query string is like

`https%253A%252F%252F<client site domain>%252Fsites%252Fdefault%252Ffiles%252Fcivicrm%252Fpersist%252Fcontribute%252Fimages%252Fuploads%252F<file name>&method=cover&params=166%252C90` 