### PR TITLE
Fix crash when upgrading 2.10 via CLI

### DIFF
--- a/CRM/Mosaico/Upgrader.php
+++ b/CRM/Mosaico/Upgrader.php
@@ -190,7 +190,7 @@ class CRM_Mosaico_Upgrader extends CRM_Mosaico_Upgrader_Base {
       ->setMatch(['name'])
       ->execute();
 
-    $existingCategories = \Civi\Api4\OptionValue::get()
+    $existingCategories = \Civi\Api4\OptionValue::get(FALSE)
       ->selectRowCount()
       ->addWhere('option_group_id.name', '=', 'mailing_template_category')
       ->execute();


### PR DESCRIPTION
This is almost identical to #523 but it happens on upgrade rather than install.