### PR TITLE
fix template paths

### DIFF
--- a/api/v3/MosaicoTemplate.php
+++ b/api/v3/MosaicoTemplate.php
@@ -73,12 +73,11 @@ function civicrm_api3_mosaico_template_get($params) {
     $metaData = json_decode($getresult['values'][0]['metadata'], TRUE);
     $baseTemplateURL = $metaData['template'];
 
-    $baseURL = CRM_Utils_System::baseURL();
-
     if (_civicrm_api3_mosaico_template_getDomainFrom($baseTemplateURL)) {
+      $baseUrlParts = parse_url(CRM_Utils_System::baseURL());
       $urlParts = parse_url($baseTemplateURL);
       $templatePath = $urlParts['path'];
-      $currentURL = CRM_Utils_System::baseURL() . $templatePath;
+      $currentURL = $baseUrlParts['scheme'] . '://' . $baseUrlParts['host'] . $templatePath;
     } else {
       $currentURL = $baseTemplateURL;
     }


### PR DESCRIPTION
Hi!

The changes in a76d59e64b8df3d318730e51f46a3b8f3551a9d9 cause the templates to no longer load correctly due to an unnecessary slash in the path.

![Bildschirmfoto vom 2022-11-10 16-33-57](https://user-images.githubusercontent.com/24728186/201219836-a94550b5-9d16-40d2-a428-203efd56bef0.png)

It looks like the [`CRM_Utils_System::baseURL()`](https://github.com/civicrm/civicrm-core/blob/0cd6b38ba721fb7f5a05da5ed7a9925adc824993/CRM/Utils/System/Drupal8.php#L786) method always returns the url with a trailing slash:
```php
$url .= $config['prefixes'][$language] . '/';
```
The `path` returned by the `parse_url()` function, on the other hand, always starts with a slash. Concatenating the two results in the extra slash in the path.

https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/blob/df6e34f035c81f3f325fd4d5504b339a5cc1c346/api/v3/MosaicoTemplate.php#L78-L84

I thought it would be sufficient to simply trim the unnecessary leading slash from the `path`:
```php
    if (_civicrm_api3_mosaico_template_getDomainFrom($baseTemplateURL)) {
      $urlParts = parse_url($baseTemplateURL);
      $templatePath = str_starts_with($urlParts['path'], '/')
        ? ltrim($urlParts['path'], '/') : $urlParts['path'];
      $currentURL = CRM_Utils_System::baseURL() . $templatePath;
    } else {
      $currentURL = CRM_Utils_System::baseURL() . $baseTemplateURL;
    }
``` 
... but apparently the language part of the url still causes the template not to load.

![Bildschirmfoto vom 2022-11-10 18-50-34](https://user-images.githubusercontent.com/24728186/201219864-b18abe93-ca84-4838-9383-79a8c33c6a86.png)

So I finally decided to split the `CRM_Utils_System::baseURL()` into its components and rebuild it with the `path` from the template.

My solution is certainly not the most elegant, but it works for now. 🙂

