### PR TITLE
fill empty option field with nbsp 

### DIFF
--- a/ang/crmMosaico/BlockMailing.html
+++ b/ang/crmMosaico/BlockMailing.html
@@ -47,7 +47,7 @@
           ng-change="checkReplyToChange(mailing)"
           ng-model="mailing.replyto_email"
       >
-        <option value=""></option>
+        <option value=""> </option>
         <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'" value="{{frm.label}}">{{frm.label}}</option>
       </select>
     </div>


### PR DESCRIPTION
With the [CiviCRM Bootstrap Theme](https://github.com/civicrm/org.civicrm.shoreditch) enabled, the Reply-To field collapses in a way that it does not work.

I added a non-breaking space to the default option so that it does not collapse. 

## Before
![Bildschirmfoto vom 2023-02-07 14-29-44](https://user-images.githubusercontent.com/24728186/217264390-bc7e3119-51f9-4507-9354-bc33b75c08a8.png)

## After
![Bildschirmfoto vom 2023-02-07 14-30-39](https://user-images.githubusercontent.com/24728186/217264417-01f6b44c-b376-4c1a-aaa7-679ef63edaee.png)