### PR TITLE
[REF] Fix test issue against current core master

### DIFF
--- a/tests/phpunit/CRM/Mosaico/AbDemuxTest.php
+++ b/tests/phpunit/CRM/Mosaico/AbDemuxTest.php
@@ -21,7 +21,7 @@ class CRM_Mosaico_AbDemuxTest extends CRM_Mosaico_TestCase implements \Civi\Test
    * Generated Entity IDs keyed by the entity name
    * @var array
    */
-  protected $ids;
+  public $ids;
 
   /**
    * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().


### PR DESCRIPTION
This aims to fix this issue that has cropped up in the recent master jenkins test runs

```
Fatal error: CRM_Mosaico_AbDemuxTest and Civi\Test\ContactTestTrait define the same property ($ids) in the composition of CRM_Mosaico_AbDemuxTest. However, the definition differs and is considered incompatible. Class was composed in /home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/ext/uk.co.vedaconsulting.mosaico/tests/phpunit/CRM/Mosaico/AbDemuxTest.php on line 13
```

ping @mattwire 