### PR TITLE
AbDemuxTest - Fix signature to match 5.64. Add comments.

### DIFF
--- a/tests/phpunit/CRM/Mosaico/AbDemuxTest.php
+++ b/tests/phpunit/CRM/Mosaico/AbDemuxTest.php
@@ -19,9 +19,17 @@ class CRM_Mosaico_AbDemuxTest extends CRM_Mosaico_TestCase implements \Civi\Test
 
   /**
    * Generated Entity IDs keyed by the entity name
+   *
+   * We don't use `$ids` directly, but `ContactTestTrait` does. Prior to
+   * 5.64, the declaration satisfied an undeclared property issue. In 5.64, it became declared
+   * (by way of `ContactTestTrait` => `EntityTrait`).
+   *
+   * For the moment, we must match `EntityTrait::$ids` exactly to be portable.
+   * Consider removing this declaration once 5.63 goes EOL.
+   *
    * @var array
    */
-  public $ids;
+  protected $ids = [];
 
   /**
    * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().


### PR DESCRIPTION
Following the merge of https://github.com/civicrm/civicrm-core/pull/26715 into `5.64.alpha`, the test suite has started to fail like this:

```
Enabling extension "uk.co.vedaconsulting.mosaico"

Fatal error: CRM_Mosaico_AbDemuxTest and Civi\Test\ContactTestTrait define the same property ($ids) in the composition of CRM_Mosaico_AbDemuxTest. However, the definition differs and is considered incompatible. Class was composed in /home/homer/buildkit/build/build-0/web/sites/all/modules/civicrm/ext/uk.co.vedaconsulting.mosaico/tests/phpunit/CRM/Mosaico/AbDemuxTest.php on line 13
```

#600 also touched on this -- but for me, #600 didn't fix the problem. The issue is that it needs to declare the default value to be compatible with `EntityTrait` (`$ids = []`).