### PR TITLE
Remove property declaration moved to the trait

### DIFF
--- a/tests/phpunit/CRM/Mosaico/AbDemuxTest.php
+++ b/tests/phpunit/CRM/Mosaico/AbDemuxTest.php
@@ -18,12 +18,6 @@ class CRM_Mosaico_AbDemuxTest extends CRM_Mosaico_TestCase implements \Civi\Test
   use \Civi\Test\MailingTestTrait;
 
   /**
-   * Generated Entity IDs keyed by the entity name
-   * @var array
-   */
-  public $ids;
-
-  /**
    * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
    * See: https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
    */


### PR DESCRIPTION
There might be some juggling here but in master this is pulled in as declared by the ContactTestTrait