### PR TITLE
issue#510 Add support for TinyMCE translations

### DIFF
--- a/CRM/Mosaico/Page/Editor.php
+++ b/CRM/Mosaico/Page/Editor.php
@@ -89,9 +89,21 @@ class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
     // Adding translation strings if exist
     $locale = CRM_Core_I18n::getLocale();
     $lang = CRM_Core_I18n_PseudoConstant::shortForLong($locale);
-    $translationFile = CRM_Core_Resources::singleton()->getPath(E::LONG_NAME, "packages/mosaico/dist/rs/lang/mosaico-{$lang}.json");
+    $translationFile = E::path("packages/mosaico/dist/rs/lang/mosaico-{$lang}.json");
     if (file_exists($translationFile)) {
       $config['strings'] = json_decode(file_get_contents($translationFile));
+    }
+
+    // TinyMCE configuration
+    // Must be a locale listed here: https://www.tiny.cloud/docs-4x/configure/localization/
+    $tinymceLocale = $this->getTinymceLocale($locale);
+    if (file_exists(E::path("packages/mosaico/dist/tinymce/langs/{$tinymceLocale}.js"))) {
+      $config['tinymceConfig']['language'] = $tinymceLocale;
+      $config['tinymceConfig']['language_url'] = "tinymce/langs/{$tinymceLocale}.js";
+    }
+    elseif (file_exists(E::path("packages/mosaico/dist/tinymce/langs/{$lang}.js"))) {
+      $config['tinymceConfig']['language'] = $lang;
+      $config['tinymceConfig']['language_url'] = "tinymce/langs/{$lang}.js";
     }
 
     // Allow configuration to be modified by a hook
@@ -155,6 +167,20 @@ class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
     $plugins = '[ ' . implode(',', $plugins) . ' ]';
 
     return $plugins;
+  }
+
+  /**
+   * Returns the closest supported locale by TinyMCE
+   *
+   * It seems like it has to be from this list:
+   * https://www.tiny.cloud/docs-4x/configure/localization/
+   * For example, fr_CA does not work, even if fr_CA.js is present
+   */
+  public function getTinymceLocale($locale) {
+    if ($locale == 'fr_CA') {
+      return 'fr_FR';
+    }
+    return $locale;
   }
 
 }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -22,3 +22,12 @@ For any image larger than that, size is reduced to 2x size of the block.
 __Note__: higher the scaling factor, higher the resolution but lower the compression.
 
 Scaling is not tied to any particular type of image. Png format supports lossless compression and therefore compression appears less than jpg images which support lossy compression.
+
+## Editor language
+
+Mosaico will attempt to use the same language as the CiviCRM interface, if the translation files are present in the `packages/mosaico/dist/rs/lang/` directory.
+
+For the TinyMCE editor that is part of Mosaico, the files must be added in `packages/mosaico/dist/tinymce/langs/xx_YY.js`. Sometimes the language is formatted as `xx_YY`, sometimes only `xx`. See the links below for the files and name:
+
+- [Download TinyMCE translations](https://www.tiny.cloud/get-tiny/language-packages/)
+- [TinyMCE locale names](https://www.tiny.cloud/docs-4x/configure/localization/)


### PR DESCRIPTION
Adds support for translating the TinyMCE editor that is part of Mosaico:

![image](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/assets/254741/8c42032c-709b-4839-94e2-1df871edb714)

Related:

- #510
- https://github.com/voidlabs/mosaico/issues/310
- [Download TinyMCE translations](https://www.tiny.cloud/get-tiny/language-packages/)
- [TinyMCE locale names](https://www.tiny.cloud/docs-4x/configure/localization/)

Ideally we would bundle the translations. Maybe during the build script?

Note that the code is a bit meh with handling the locale codes, because for some reason some use the long-form `xx_YY` and some use the short form, and then it just won't support some locales such as `fr_CA`, even if the translation is there.

Once the PR is merged, to add the translations, they must be copied to either the short of long form, such as:

- `packages/mosaico/dist/tinymce/langs/fr_FR.js`
- `packages/mosaico/dist/tinymce/langs/fr.js`

.. depending on the locale name listed here: https://www.tiny.cloud/docs-4x/configure/localization/

for some locales, we might need in the future to adapt the `getTinymceLocale` function to support more language variants (for now it only supports `fr_CA`).