### PR TITLE
Fix notice error about no buffer to flush

### DIFF
--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -431,7 +431,9 @@ class CRM_Mosaico_Utils {
     header("Content-type:" . $mime_type);
 
     readfile($file);
-    ob_flush();
+    if (ob_get_length()) {
+      ob_flush();
+    }
     flush();
   }
 


### PR DESCRIPTION
On a client's D9 Site I was seeing this in the watchdog "Notice: ob_flush(): Failed to flush buffer. No buffer to flush in CRM_Mosaico_Utils::sendImage()"