### PR TITLE
Angular - Switch to settingsFactory

### DIFF
--- a/CRM/Mosaico/Utils.php
+++ b/CRM/Mosaico/Utils.php
@@ -437,4 +437,17 @@ class CRM_Mosaico_Utils {
     flush();
   }
 
+  public static function getAngularSettings(): array {
+    return [
+      'canDelete' => Civi::service('civi_api_kernel')->runAuthorize('MosaicoTemplate', 'delete', ['version' => 3, 'check_permissions' => 1]),
+      // If there are any navbars that we should try to avoid, include them
+      // in these jQuery selectors.
+      'topNav' => '#civicrm-menu',
+      'drupalNav' => '#toolbar',
+      'joomlaNav' => '.com_civicrm > .navbar',
+      'leftNav' => '.wp-admin #adminmenu',
+      'variantsPct' => CRM_Mosaico_AbDemux::DEFAULT_AB_PERCENTAGE,
+    ];
+  }
+
 }

--- a/ang/crmMosaico.ang.php
+++ b/ang/crmMosaico.ang.php
@@ -1,36 +1,17 @@
 <?php
-// This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+// Main Angular module for Mosaico
 
-$canRead = Civi::service('civi_api_kernel')->runAuthorize('MosaicoTemplate', 'get', ['version' => 3, 'check_permissions' => 1]);
-if (!$canRead) {
-  return [];
-}
-
-$result = [
+return [
   'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'crmMailing', 'crmDialog'],
-  'js' =>
-  [
-    0 => 'ang/crmMosaico.js',
-    1 => 'ang/crmMosaico/*.js',
-    2 => 'ang/crmMosaico/*/*.js',
+  'js' => [
+    'ang/crmMosaico.js',
+    'ang/crmMosaico/*.js',
+    'ang/crmMosaico/*/*.js',
   ],
   'css' => ['css/mosaico-bootstrap.css'],
   'bundles' => ['bootstrap3'],
   'partials' => [
     'ang/crmMosaico',
   ],
-  'settings' =>
-  [
-    'canDelete' => Civi::service('civi_api_kernel')->runAuthorize('MosaicoTemplate', 'delete', ['version' => 3, 'check_permissions' => 1]),
-    // If there are any navbars that we should try to avoid, include them
-    // in these jQuery selectors.
-    'topNav' => '#civicrm-menu',
-    'drupalNav' => '#toolbar',
-    'joomlaNav' => '.com_civicrm > .navbar',
-    'leftNav' => '.wp-admin #adminmenu',
-    'variantsPct' => CRM_Mosaico_AbDemux::DEFAULT_AB_PERCENTAGE,
-  ],
+  'settingsFactory' => ['CRM_Mosaico_Utils', 'getAngularSettings'],
 ];
-return $result;


### PR DESCRIPTION
Fixes a pattern that was [deprecated back in 2020](https://github.com/civicrm/civicrm-core/commit/d56e4a996cf9de952db80c3823d572d2889365c0)

The "quirky filter" was preserved in a449c021d043dabe7343bf03daa11af2dd9c57f7 as a hedge but I think we can just delete it.