### PR TITLE
Avoid calling preg_replace on array content

### DIFF
--- a/CRM/Mosaico/ImageFilter.php
+++ b/CRM/Mosaico/ImageFilter.php
@@ -33,13 +33,17 @@ class CRM_Mosaico_ImageFilter extends \Civi\FlexMailer\Listener\BaseListener {
 
     $mosaico_image_upload_dir = rawurlencode($this->config['BASE_URL'] . $this->config['UPLOADS_URL']);
 
-    $e->content = preg_replace_callback(
-      "/src=\".+img[\/]?\?src=(" . $mosaico_image_upload_dir . ")(.+)&.*\"/U",
-      function($matches){
-        return "src=\"" . rawurldecode($matches[1]) . "static/" . rawurldecode($matches[2]) . "\"";
-      },
-      $e->content
-    );
+    foreach ($e->content as $key => $item) {
+      if(!is_array($item)) {
+        $e->content[$key] = preg_replace_callback(
+          "/src=\".+img[\/]?\?src=(" . $mosaico_image_upload_dir . ")(.+)&.*\"/U",
+          function($matches){
+            return "src=\"" . rawurldecode($matches[1]) . "static/" . rawurldecode($matches[2]) . "\"";
+          },
+          $item
+        );
+      }
+    }
   }
 
 }


### PR DESCRIPTION
In our company we are using some extensions and patches to CRM Core that alter CRM_Core_BAO_MessageTemplate::sendTemplate params, adding an array of additional params like event info.

After our changes \Civi\Core\Event\GenericHookEvent $e->content contains one item that is not string, but array so calling preg_replace_callback on all items removes our data.

This change won't affect any of [uk.co.vedaconsulting.mosaico] functions but will save lot work in our side.

**I will be very grateful if you implement this change**