### PR TITLE
Update info.xml to link to correct page to download from and where to report issues.

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -9,10 +9,10 @@
     <email>mjw@mjwconsult.co.uk, deepak@mountev.co.uk</email>
   </maintainer>
   <urls>
-    <url desc="Main Extension Page">https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico</url>
+    <url desc="Main Extension Page">https://civicrm.org/extensions/email-template-builder</url>
     <url desc="Documentation">https://docs.civicrm.org/mosaico/en/latest</url>
     <url desc="Release Notes">https://docs.civicrm.org/mosaico/en/latest/releasenotes/</url>
-    <url desc="Support">https://vedaconsulting.co.uk</url>
+    <url desc="Support">https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2023-10-15</releaseDate>


### PR DESCRIPTION
Update info.xml to link to correct page to download from and where to report issues.

Download URL, https://civicrm.org/extensions/email-template-builder
Issues URL, https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/issues

It's confusing to direct users to download from Github and then on the README has a link to the CiviCRM extensions page and instructions to NOT download from Github.