### PR TITLE
Error in call to mosaico_wrapMailingApi

### DIFF
--- a/CRM/Mosaico/Services.php
+++ b/CRM/Mosaico/Services.php
@@ -31,7 +31,7 @@ class CRM_Mosaico_Services {
     }
     // The api prepare event might be called before civicrm configuration is fully loaded. So we use the function mosaico_wrapMailingApi from
     // mosaico.php as that file is definitely loaded.
-    $container->findDefinition('dispatcher')->addMethodCall('addListener', ['civi.api.prepare', 'mosaico_wrapMailingApi', Civi\API\Events::W_LATE]);
+    $container->findDefinition('dispatcher')->addMethodCall('addListener', ['civi.api.prepare', '\mosaico_wrapMailingApi', Civi\API\Events::W_LATE]);
   }
 
   protected static function getListenerSpecs() {


### PR DESCRIPTION
I'm not sure about this because I don't know how to reproduce it, but on some sites (drupal 9) it doesn't seem to be able to find this function without the backslash in front. The symptom is a blank new mailing page. But e.g. it seems fine on https://d9-master.demo.civicrm.org. But adding the backslash doesn't seem like it would hurt?

Possibly differences in symfony version? Or there was a suggestion drupal multilingual.