### PR TITLE
Move navigation menu items declarations to managed entities

### DIFF
--- a/managed/Navigation_mosaico.mgd.php
+++ b/managed/Navigation_mosaico.mgd.php
@@ -1,0 +1,83 @@
+<?php
+
+use CRM_Mosaico_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'Navigation_mosaico_traditional_mailing',
+    'entity' => 'Navigation',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'label' => E::ts('New Mailing (Traditional)'),
+        'name' => 'traditional_mailing',
+        'url' => CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mailing/new/traditional'),
+        'icon' => '',
+        'permission' => [
+          'access CiviMail',
+          'create mailings',
+        ],
+        'permission_operator' => 'OR',
+        'parent_id.name' => 'Mailings',
+        'has_separator' => 1,
+        'weight' => 2,
+      ],
+      'match' => [
+        'domain_id',
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'Navigation_mosaico_message_templates',
+    'entity' => 'Navigation',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'label' => E::ts('Mosaico Templates'),
+        'name' => 'mosaico_templates',
+        'url' => 'civicrm/mosaico-template-list',
+        'icon' => '',
+        'permission' => [
+          'edit message templates',
+        ],
+        'permission_operator' => 'OR',
+        'parent_id.name' => 'Mailings',
+        'weight' => 8,
+      ],
+      'match' => [
+        'domain_id',
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'Navigation_mosaico_settings',
+    'entity' => 'Navigation',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'label' => E::ts('Mosaico Settings'),
+        'name' => 'mosaico_settings',
+        'url' => CRM_Utils_System::url('civicrm/admin/setting/mosaico', 'reset=1', TRUE),
+        'icon' => '',
+        'permission' => [
+          'administer CiviCRM',
+        ],
+        'permission_operator' => 'OR',
+        'parent_id.name' => 'CiviMail',
+        'weight' => 100,
+      ],
+      'match' => [
+        'domain_id',
+        'name',
+      ],
+    ],
+  ],
+];

--- a/mosaico.php
+++ b/mosaico.php
@@ -54,40 +54,6 @@ function mosaico_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
   $angular->add($changeSet);
 }
 
-function mosaico_civicrm_navigationMenu(&$params) {
-  _mosaico_civix_insert_navigation_menu($params, 'Mailings', [
-    'label' => E::ts('Mosaico Templates'),
-    'name' => 'mosaico_templates',
-    'permission' => 'edit message templates',
-    'child' => [],
-    'operator' => 'AND',
-    'separator' => 0,
-    'url' => CRM_Utils_System::url('civicrm/mosaico-template-list'),
-  ]);
-
-  _mosaico_civix_insert_navigation_menu($params, 'Mailings', [
-    'label' => E::ts('New Mailing (Traditional)'),
-    'name' => 'traditional_mailing',
-    'permission' => 'access CiviMail,create mailings',
-    'child' => [],
-    'operator' => 'OR',
-    'separator' => 0,
-    'url' => CRM_Utils_System::url('civicrm/a/', NULL, TRUE, '/mailing/new/traditional'),
-  ]);
-
-  _mosaico_civix_insert_navigation_menu($params, 'Administer/CiviMail', [
-    'label' => E::ts('Mosaico Settings'),
-    'name' => 'mosaico_settings',
-    'permission' => 'administer CiviCRM',
-    'child' => [],
-    'operator' => 'AND',
-    'separator' => 0,
-    'url' => CRM_Utils_System::url('civicrm/admin/setting/mosaico', 'reset=1', TRUE),
-  ]);
-
-  _mosaico_civix_navigationMenu($params);
-}
-
 /**
  * Implements hook_civicrm_alterAPIPermissions().
  *


### PR DESCRIPTION
Moves the declarations of the Mosaico menu items to  "managed" entity declarations, so that : 

- They can be edited from the admin interface (manage navigation menu)
- They can be positioned more precisely.

![image](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/assets/254741/a14bed96-9ef0-4181-aedf-7e1614100e6a)

The clutter in this menu still makes my head explode, but at least the items are placed more logically, and easier to customize by admins. The rest is mostly an issue in core.