### PR TITLE
Add A/B testing for email design

### DIFF
--- a/ang/crmMosaico/BlockDesign.html
+++ b/ang/crmMosaico/BlockDesign.html
@@ -1,20 +1,20 @@
 <div class="mosaico-templates-wrapper">
   <div class="row">
-    <span ng-model="body_html_defined" crm-ui-validate="mosaicoCtrl.hasMarkup(mailing)"></span>
+    <span ng-model="body_html_defined" crm-ui-validate="mosaicoCtrl.hasMarkup()"></span>
     <div class="col-xs-4 col-md-4 crm-mosaico-selected center-block"
-         crm-mosaico-template-item="{state:'selected', title: ts('My Design'), subtitle: mosaicoCtrl.getTemplate(mailing).type, img: mosaicoCtrl.getTemplate(mailing).thumbnail}"
-         on-item-click="mosaicoCtrl.edit(mailing)"
-         on-item-reset="mosaicoCtrl.reset(mailing)"
-         ng-show="mosaicoCtrl.hasSelection(mailing)">
+         crm-mosaico-template-item="{state:'selected', title: ts('My Design'), subtitle: mosaicoCtrl.getTemplate().type, img: mosaicoCtrl.getTemplate().thumbnail}"
+         on-item-click="mosaicoCtrl.edit()"
+         on-item-reset="mosaicoCtrl.reset()"
+         ng-show="mosaicoCtrl.hasSelection()">
     </div>
-    <div ng-if="!mosaicoCtrl.hasSelection(mailing) && mosaicoCtrl.templates.length">
+    <div ng-if="!mosaicoCtrl.hasSelection() && mosaicoCtrl.templates.length">
       <div class="form-inline">
         <input class="form-control crm-mosaico-template-category" ng-model="mosaicoCtrl.selectedCategory" ng-change="mosaicoCtrl.categoryFilter = mosaicoCtrl.categoryFilters[mosaicoCtrl.selectedCategory].filter" crm-ui-select="{data: mosaicoCtrl.categoryFilters, placeholder: ts('All Categories')}">
       </div>
       <div ng-repeat="template in mosaicoCtrl.templates | filter:mosaicoCtrl.categoryFilter" class="mosaico-templates-list">
         <div class="col-xs-6 col-md-4"
              crm-mosaico-template-item="{state:'select', title: (template.base ? template.title : template.type), subtitle: template.category, img: template.thumbnail}"
-             on-item-click="mosaicoCtrl.select(mailing, template)">
+             on-item-click="mosaicoCtrl.select(template)">
         </div>
       </div>
     </div>

--- a/ang/crmMosaico/BlockDesign.html
+++ b/ang/crmMosaico/BlockDesign.html
@@ -1,13 +1,13 @@
 <div class="mosaico-templates-wrapper">
   <div class="row">
-    <span ng-model="body_html_defined" crm-ui-validate="!!mailing.body_html"></span>
+    <span ng-model="body_html_defined" crm-ui-validate="mosaicoCtrl.hasMarkup(mailing)"></span>
     <div class="col-xs-4 col-md-4 crm-mosaico-selected center-block"
          crm-mosaico-template-item="{state:'selected', title: ts('My Design'), subtitle: mosaicoCtrl.getTemplate(mailing).type, img: mosaicoCtrl.getTemplate(mailing).thumbnail}"
          on-item-click="mosaicoCtrl.edit(mailing)"
          on-item-reset="mosaicoCtrl.reset(mailing)"
-         ng-show="!!mailing.template_options.mosaicoTemplate">
+         ng-show="mosaicoCtrl.hasSelection(mailing)">
     </div>
-    <div ng-if="!mailing.template_options.mosaicoTemplate && mosaicoCtrl.templates.length">
+    <div ng-if="!mosaicoCtrl.hasSelection(mailing) && mosaicoCtrl.templates.length">
       <div class="form-inline">
         <input class="form-control crm-mosaico-template-category" ng-model="mosaicoCtrl.selectedCategory" ng-change="mosaicoCtrl.categoryFilter = mosaicoCtrl.categoryFilters[mosaicoCtrl.selectedCategory].filter" crm-ui-select="{data: mosaicoCtrl.categoryFilters, placeholder: ts('All Categories')}">
       </div>

--- a/ang/crmMosaico/BlockDesign.js
+++ b/ang/crmMosaico/BlockDesign.js
@@ -24,7 +24,8 @@
         $scope.mosaicoCtrl = {
           templates: [],
           // Fill a given "mailing" which the chosen "template".
-          select: function(mailing, template) {
+          select: function(template) {
+            const mailing = scope.mailing;
             var topt = mailing.template_options = mailing.template_options || {};
             var promise = crmMosaicoTemplates.getFull(template).then(function(tplCtnt){
               topt.mosaicoTemplate = template.id;
@@ -32,18 +33,21 @@
               topt.mosaicoContent = tplCtnt.content;
               mailing.body_html = tplCtnt.html;
               // console.log('select', {isAr1: _.isArray(mailing.template_options), isAr2: _.isArray(topt), m: mailing, t: template});
-              $scope.mosaicoCtrl.edit(mailing);
+              $scope.mosaicoCtrl.edit();
             });
             return crmStatus({start: ts('Loading...'), success: null}, promise);
           },
-          hasSelection: function(mailing) {
+          hasSelection: function() {
+            const mailing = scope.mailing;
             return !!mailing.template_options.mosaicoTemplate;
           },
-          hasMarkup: function(mailing) {
+          hasMarkup: function() {
+            const mailing = scope.mailing;
             return !!mailing.body_html;
           },
           // Figure out which "template" was previously used with a "mailing."
-          getTemplate: function(mailing) {
+          getTemplate: function() {
+            const mailing = scope.mailing;
             if (!mailing || !mailing.template_options || !mailing.template_options.mosaicoTemplate) {
               return null;
             }
@@ -53,7 +57,8 @@
             return matches.length > 0 ? matches[0] : null;
           },
           // Reset all Mosaico data in a "mailing'.
-          reset: function(mailing) {
+          reset: function() {
+            const mailing = scope.mailing;
             if (crmMosaicoIframe) crmMosaicoIframe.destroy();
             crmMosaicoIframe = null;
             delete mailing.template_options.mosaicoTemplate;
@@ -62,7 +67,8 @@
             mailing.body_html = '';
           },
           // Edit a mailing in Mosaico.
-          edit: function(mailing) {
+          edit: function() {
+            const mailing = scope.mailing;
             if (crmMosaicoIframe) {
               crmMosaicoIframe.show();
               return;
@@ -78,7 +84,7 @@
 
             crmMosaicoIframe = new CrmMosaicoIframe({
               model: {
-                template: $scope.mosaicoCtrl.getTemplate(mailing).path,
+                template: $scope.mosaicoCtrl.getTemplate().path,
                 metadata: mailing.template_options.mosaicoMetadata,
                 content: mailing.template_options.mosaicoContent
               },

--- a/ang/crmMosaico/BlockDesign.js
+++ b/ang/crmMosaico/BlockDesign.js
@@ -111,7 +111,7 @@
                 test: function(ko, viewModel) {
                   syncModel(viewModel);
 
-                  var model = {mailing: $scope.mailing, attachments: $scope.attachments};
+                  var model = {mailing: $scope.mailing, attachments: $scope.attachments, variantId: $scope.variantId};
                   var options = CRM.utils.adjustDialogDefaults(angular.extend(
                     {autoOpen: false, title: ts('Preview / Test'), width: 550},
                     options

--- a/ang/crmMosaico/BlockDesign.js
+++ b/ang/crmMosaico/BlockDesign.js
@@ -36,6 +36,12 @@
             });
             return crmStatus({start: ts('Loading...'), success: null}, promise);
           },
+          hasSelection: function(mailing) {
+            return !!mailing.template_options.mosaicoTemplate;
+          },
+          hasMarkup: function(mailing) {
+            return !!mailing.body_html;
+          },
           // Figure out which "template" was previously used with a "mailing."
           getTemplate: function(mailing) {
             if (!mailing || !mailing.template_options || !mailing.template_options.mosaicoTemplate) {

--- a/ang/crmMosaico/BlockDesign.js
+++ b/ang/crmMosaico/BlockDesign.js
@@ -3,12 +3,16 @@
     return {
       scope: {
         crmMosaicoCtrl: '@',
-        crmMailing: '@'
+        crmMailing: '@',
+        crmMailingAttachments: '@'
       },
       templateUrl: '~/crmMosaico/BlockDesign.html',
       link: function (scope, elm, attr) {
         scope.$parent.$watch(attr.crmMailing, function(newValue){
           scope.mailing = newValue;
+        });
+        scope.$parent.$watch(attr.crmMailingAttachments, function(newValue){
+          scope.attachments = newValue;
         });
         scope.$parent.$watch(attr.crmMosaicoCtrl, function(newValue){
           scope.mosaicoCtrl = newValue;

--- a/ang/crmMosaico/BlockDesign.js
+++ b/ang/crmMosaico/BlockDesign.js
@@ -1,10 +1,11 @@
 (function(angular, $, _) {
-  angular.module('crmMosaico').directive('crmMosaicoBlockDesign', function($q, crmUiHelp) {
+  angular.module('crmMosaico').directive('crmMosaicoBlockDesign', function($q, crmUiHelp, dialogService, crmMosaicoTemplates, crmStatus, CrmMosaicoIframe, $timeout) {
+
     return {
       scope: {
-        crmMosaicoCtrl: '@',
+        // crmMosaicoCtrl: '@',
         crmMailing: '@',
-        crmMailingAttachments: '@'
+        crmMailingAttachments: '@',
       },
       templateUrl: '~/crmMosaico/BlockDesign.html',
       link: function (scope, elm, attr) {
@@ -14,12 +15,119 @@
         scope.$parent.$watch(attr.crmMailingAttachments, function(newValue){
           scope.attachments = newValue;
         });
-        scope.$parent.$watch(attr.crmMosaicoCtrl, function(newValue){
-          scope.mosaicoCtrl = newValue;
-        });
         scope.crmMailingConst = CRM.crmMailing;
         scope.ts = CRM.ts(null);
         scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
+
+        const $scope = scope;
+        var crmMosaicoIframe = null, activeDialogs = {};
+        $scope.mosaicoCtrl = {
+          templates: [],
+          // Fill a given "mailing" which the chosen "template".
+          select: function(mailing, template) {
+            var topt = mailing.template_options = mailing.template_options || {};
+            var promise = crmMosaicoTemplates.getFull(template).then(function(tplCtnt){
+              topt.mosaicoTemplate = template.id;
+              topt.mosaicoMetadata = tplCtnt.metadata;
+              topt.mosaicoContent = tplCtnt.content;
+              mailing.body_html = tplCtnt.html;
+              // console.log('select', {isAr1: _.isArray(mailing.template_options), isAr2: _.isArray(topt), m: mailing, t: template});
+              $scope.mosaicoCtrl.edit(mailing);
+            });
+            return crmStatus({start: ts('Loading...'), success: null}, promise);
+          },
+          // Figure out which "template" was previously used with a "mailing."
+          getTemplate: function(mailing) {
+            if (!mailing || !mailing.template_options || !mailing.template_options.mosaicoTemplate) {
+              return null;
+            }
+            var matches = _.where($scope.mosaicoCtrl.templates, {
+              id: mailing.template_options.mosaicoTemplate
+            });
+            return matches.length > 0 ? matches[0] : null;
+          },
+          // Reset all Mosaico data in a "mailing'.
+          reset: function(mailing) {
+            if (crmMosaicoIframe) crmMosaicoIframe.destroy();
+            crmMosaicoIframe = null;
+            delete mailing.template_options.mosaicoTemplate;
+            delete mailing.template_options.mosaicoMetadata;
+            delete mailing.template_options.mosaicoContent;
+            mailing.body_html = '';
+          },
+          // Edit a mailing in Mosaico.
+          edit: function(mailing) {
+            if (crmMosaicoIframe) {
+              crmMosaicoIframe.show();
+              return;
+            }
+
+            function syncModel(viewModel) {
+              mailing.body_html = viewModel.exportHTML();
+              mailing.template_options = mailing.template_options || {};
+              // Mosaico exports JSON. Keep their original encoding... or else the loader throws an error.
+              mailing.template_options.mosaicoMetadata = viewModel.exportMetadata();
+              mailing.template_options.mosaicoContent = viewModel.exportJSON();
+            }
+
+            crmMosaicoIframe = new CrmMosaicoIframe({
+              model: {
+                template: $scope.mosaicoCtrl.getTemplate(mailing).path,
+                metadata: mailing.template_options.mosaicoMetadata,
+                content: mailing.template_options.mosaicoContent
+              },
+              actions: {
+                sync: function(ko, viewModel) {
+                  syncModel(viewModel);
+                },
+                close: function(ko, viewModel) {
+                  viewModel.metadata.changed = Date.now();
+                  syncModel(viewModel);
+                  // TODO: When autosave is better integrated, remove this.
+                  $timeout(function(){
+                    $scope.$parent.$apply(attr.onSave);
+                  }, 100);
+                  crmMosaicoIframe.hide('crmMosaicoEditorDialog');
+                },
+                test: function(ko, viewModel) {
+                  syncModel(viewModel);
+
+                  var model = {mailing: $scope.mailing, attachments: $scope.attachments};
+                  console.log('test!', model);
+                  var options = CRM.utils.adjustDialogDefaults(angular.extend(
+                    {autoOpen: false, title: ts('Preview / Test'), width: 550},
+                    options
+                  ));
+                  activeDialogs.crmMosaicoPreviewDialog = 1;
+                  var pr = dialogService.open('crmMosaicoPreviewDialog', '~/crmMosaico/PreviewDialogCtrl.html', model, options)
+                    .finally(function(){ delete activeDialogs.crmMosaicoPreviewDialog; });
+                  return pr;
+                }
+              }
+            });
+
+            return crmStatus({start: ts('Loading...'), success: null}, crmMosaicoIframe.open());
+          }
+        };
+
+        crmMosaicoTemplates.whenLoaded().then(function(){
+          $scope.mosaicoCtrl.templates = crmMosaicoTemplates.getAll();
+          $scope.mosaicoCtrl.categoryFilters = _.transform(crmMosaicoTemplates.getCategories(), function(filters, category) {
+            filters.push({id: filters.length, text: category.label, filter: {category_id: category.value}});
+          }, [{id: 0, text: ts('Base Template'), filter: {isBase: true}}]);
+        });
+
+        $scope.$on("$destroy", function() {
+          angular.forEach(activeDialogs, function(v,name){
+            dialogService.cancel(name);
+          });
+          if (crmMosaicoIframe) {
+            crmMosaicoIframe.destroy();
+            crmMosaicoIframe = null;
+          }
+        });
+
+
       }
     };
   });

--- a/ang/crmMosaico/BlockMailing.html
+++ b/ang/crmMosaico/BlockMailing.html
@@ -65,8 +65,8 @@
     </div>
   </div>
 
-  <div class="form-group" ng-if="mailing.template_options.variants && mailing.template_options.variants[0].subject && mailing.template_options.variants[1].subject">
-    <em>({{ts('You have chosen two subject lines. We will organize a A/B testing to determine which is better.')}})</em>
+  <div class="form-group" ng-if="isMailingSplit(mailing, 'subject')">
+    <em>({{ts('Define two options for the subject. We will use A/B testing to determine which is better.')}})</em>
   </div>
 
   <span ng-controller="EditUnsubGroupCtrl">

--- a/ang/crmMosaico/BlockMailing.html
+++ b/ang/crmMosaico/BlockMailing.html
@@ -65,9 +65,8 @@
     </div>
   </div>
 
-  <div class="form-group" ng-if="mailing.template_options.variants">
-    <label class="control-label">{{ts('Distribution')}}</label>
-    <crm-mosaico-distribution crm-mailing="mailing" />
+  <div class="form-group" ng-if="mailing.template_options.variants && mailing.template_options.variants[0].subject && mailing.template_options.variants[1].subject">
+    <em>({{ts('You have chosen two subject lines. We will organize a A/B testing to determine which is better.')}})</em>
   </div>
 
   <span ng-controller="EditUnsubGroupCtrl">

--- a/ang/crmMosaico/BlockMailing.js
+++ b/ang/crmMosaico/BlockMailing.js
@@ -1,5 +1,11 @@
 (function(angular, $, _) {
-  angular.module('crmMosaico').directive('crmMosaicoBlockMailing', function(crmMailingSimpleDirective) {
-    return crmMailingSimpleDirective('crmMosaicoBlockMailing', '~/crmMosaico/BlockMailing.html');
+  angular.module('crmMosaico').directive('crmMosaicoBlockMailing', function(crmMailingSimpleDirective, crmMosaicoVariants) {
+    const d = crmMailingSimpleDirective('crmMosaicoBlockMailing', '~/crmMosaico/BlockMailing.html');
+    const link = d.link;
+    d.link = function(scope, elm, attr) {
+      link(scope, elm, attr);
+      scope.isMailingSplit = (mailing, field) => crmMosaicoVariants.isSplit(mailing, field);
+    };
+    return d;
   });
 })(angular, CRM.$, CRM._);

--- a/ang/crmMosaico/BlockPreview.html
+++ b/ang/crmMosaico/BlockPreview.html
@@ -44,3 +44,7 @@ Vars: mailing:obj, testContact:obj, testGroup:obj, crmMailing:FormController
   <button type="button" class="btn btn-sm btn-primary" title="{{ crmMailing.$invalid || !testGroup.gid ? ts('Complete all required-mark fields first') : ts('Send test message to group') }}" ng-disabled="crmMailing.$invalid || !testGroup.gid" crm-confirm="{resizable: true, width: '40%', height: '40%', open: previewTestGroup}"
       on-yes="doSend({gid: testGroup.gid})">{{:: ts('Send test') }}</button>
 </div>
+
+<div class="form-group" ng-if="isSplit(mailing)">
+  <em>{{ts('The draft mailing allows two variations (A/B).')}}<br/>{{ts('If you send a test now, it will use all available variations.')}}</em>
+</div>

--- a/ang/crmMosaico/BlockPreview.js
+++ b/ang/crmMosaico/BlockPreview.js
@@ -2,7 +2,7 @@
   // example: <div crm-mailing-block-preview crm-mailing="myMailing" on-preview="openPreview(myMailing, preview.mode)" on-send="sendEmail(myMailing,preview.recipient)">
   // note: the directive defines a variable called "preview" with any inputs supplied by the user (e.g. the target recipient for an example mailing)
 
-  angular.module('crmMosaico').directive('crmMosaicoBlockPreview', function(crmUiHelp) {
+  angular.module('crmMosaico').directive('crmMosaicoBlockPreview', function(crmUiHelp, crmMosaicoVariants) {
     return {
       templateUrl: '~/crmMosaico/BlockPreview.html',
       link: function(scope, elm, attr) {
@@ -25,6 +25,7 @@
 
           return ($.inArray(false, validityArr) == -1);
         };
+        scope.isSplit = crmMosaicoVariants.isSplit;
 
         scope.doPreview = function(mode) {
           scope.$eval(attr.onPreview, {

--- a/ang/crmMosaico/BlockSchedule.html
+++ b/ang/crmMosaico/BlockSchedule.html
@@ -1,5 +1,11 @@
 <div class="crmMosaico-schedule-outer" crm-mailing-radio-date="schedule" ng-model="mailing.scheduled_date">
 
+  <div class="form-group" ng-if="!!mailing.template_options.variants">
+    <label class="control-label">{{ts('Testing')}}</label>
+    <p><em>{{ts('You have enabled A/B testing. We will send each test message to a subset of your subscribers. Later, you can decide the final mailing.')}}</em></p>
+    <crm-mosaico-distribution crm-mailing="mailing" />
+  </div>
+
   <label class="crmMosaico-schedule-title">{{ts('Schedule email to:')}}</label>
 
   <div class="crmMosaico-schedule-inner form-inline form-inline-tabs" ng-init="selectedTab = 'sendNow'">

--- a/ang/crmMosaico/EditMailingCtrl/bootstrap-single.html
+++ b/ang/crmMosaico/EditMailingCtrl/bootstrap-single.html
@@ -12,7 +12,7 @@
           <div style="clear: both"></div>
         </div>
         <div class="panel-body">
-          <div crm-mosaico-block-design crm-mailing="mailing" crm-mosaico-ctrl="mosaicoCtrl"></div>
+          <div crm-mosaico-block-design crm-mailing="mailing" crm-mailing-attachments="attachments" crm-mosaico-ctrl="mosaicoCtrl"></div>
         </div>
 
         <div class="panel-heading">

--- a/ang/crmMosaico/EditMailingCtrl/bootstrap-single.html
+++ b/ang/crmMosaico/EditMailingCtrl/bootstrap-single.html
@@ -7,12 +7,29 @@
         <div class="panel-heading">{{ts('Mailing')}}</div>
         <div class="panel-body" crm-mosaico-block-mailing crm-mailing="mailing"></div>
 
-        <div class="panel-heading">
-          <span class="required-mark">{{ts('Design')}}</span>
+        <div class="panel-heading" ng-repeat-start="design in getDesigns(mailing)">
+          <div style="float: right" ng-if="!!design.action">
+            <button ng-if="design.action === 'split'"
+                    class="btn btn-primary-outline btn-xs"
+                    crm-confirm="{message: ts('With A/B testing, you can design two alternative versions of the mailing.')}"
+                    on-yes="splitDesign(mailing)">
+              <span class="fa fa-copy" aria-hidden="true"></span>
+              {{ts('A/B Test')}}
+            </button>
+            <button ng-if="design.action === 'unsplit'"
+                    class="btn btn-primary-outline btn-xs"
+                    crm-confirm="{message: ts('Are you sure you want to delete %1? The other design will become primary.', {1: design.title})}"
+                    on-yes="unsplitDesign(mailing, design.vid)">
+              <span class="fa fa-trash" aria-hidden="true"></span>
+              {{ts('Delete')}}
+            </button>
+          </div>
+
+          <span class="required-mark">{{design.title}}</span>
           <div style="clear: both"></div>
         </div>
-        <div class="panel-body">
-          <div crm-mosaico-block-design crm-mailing="mailing" crm-mailing-attachments="attachments" on-save="save()"></div>
+        <div class="panel-body" ng-repeat-end>
+          <div crm-mosaico-block-design crm-mailing="mailing" crm-mailing-attachments="attachments" crm-mailing-variant="design.vid" on-save="save()"></div>
         </div>
 
         <div class="panel-heading">

--- a/ang/crmMosaico/EditMailingCtrl/bootstrap-single.html
+++ b/ang/crmMosaico/EditMailingCtrl/bootstrap-single.html
@@ -12,7 +12,7 @@
           <div style="clear: both"></div>
         </div>
         <div class="panel-body">
-          <div crm-mosaico-block-design crm-mailing="mailing" crm-mailing-attachments="attachments" crm-mosaico-ctrl="mosaicoCtrl"></div>
+          <div crm-mosaico-block-design crm-mailing="mailing" crm-mailing-attachments="attachments" on-save="save()"></div>
         </div>
 
         <div class="panel-heading">

--- a/ang/crmMosaico/EditMailingCtrl/bootstrap-wizard.html
+++ b/ang/crmMosaico/EditMailingCtrl/bootstrap-wizard.html
@@ -7,7 +7,7 @@
       </div>
 
       <div crmb-wizard-step crm-title="ts('Design')" ng-form="designForm">
-        <div crm-mosaico-block-design crm-mailing="mailing" crm-mailing-attachments="attachments" crm-mosaico-ctrl="mosaicoCtrl"></div>
+        <div crm-mosaico-block-design crm-mailing="mailing" crm-mailing-attachments="attachments" on-save="save()"></div>
       </div>
 
       <div crmb-wizard-step crm-title="ts('Options')" ng-form="optionsForm">

--- a/ang/crmMosaico/EditMailingCtrl/bootstrap-wizard.html
+++ b/ang/crmMosaico/EditMailingCtrl/bootstrap-wizard.html
@@ -7,7 +7,43 @@
       </div>
 
       <div crmb-wizard-step crm-title="ts('Design')" ng-form="designForm">
-        <div crm-mosaico-block-design crm-mailing="mailing" crm-mailing-attachments="attachments" on-save="save()"></div>
+
+        <div ng-if="!isMailingSplit(mailing, 'body_html')">
+          <div crm-mosaico-block-design crm-mailing="mailing" crm-mailing-variant="null" crm-mailing-attachments="attachments" on-save="save()"></div>
+
+          <div class="text-center">
+            <button class="btn btn-primary-outline btn-xs"
+                    crm-confirm="{message: ts('With A/B testing, you can design two alternative versions of the mailing.')}"
+                    on-yes="splitDesign(mailing)">
+              <span class="fa fa-copy" aria-hidden="true"></span>
+              {{ts('Add A/B Test')}}
+            </button>
+          </div>
+        </div>
+
+        <div ng-if="isMailingSplit(mailing, 'body_html')">
+          <p class="text-center"><em>({{ts('Define two options for the design. We will use A/B testing to determine which is better.')}})</em></p>
+
+          <div class="panel panel-default" ng-repeat="design in getDesigns(mailing)">
+            <div class="panel-heading" >
+              <div style="float: right">
+                <button class="btn btn-primary-outline btn-xs"
+                        crm-confirm="{message: ts('Are you sure you want to delete %1? The other design will become primary.', {1: design.title})}"
+                        on-yes="unsplitDesign(mailing, design.vid)">
+                  <span class="fa fa-trash" aria-hidden="true"></span>
+                  {{ts('Delete')}}
+                </button>
+              </div>
+
+              <span class="required-mark">{{design.title}}</span>
+              <div style="clear: both"></div>
+            </div>
+            <div class="panel-body">
+              <div crm-mosaico-block-design crm-mailing="mailing" crm-mailing-attachments="attachments" crm-mailing-variant="design.vid" on-save="save()"></div>
+            </div>
+          </div>
+        </div>
+
       </div>
 
       <div crmb-wizard-step crm-title="ts('Options')" ng-form="optionsForm">

--- a/ang/crmMosaico/EditMailingCtrl/bootstrap-wizard.html
+++ b/ang/crmMosaico/EditMailingCtrl/bootstrap-wizard.html
@@ -7,7 +7,7 @@
       </div>
 
       <div crmb-wizard-step crm-title="ts('Design')" ng-form="designForm">
-        <div crm-mosaico-block-design crm-mailing="mailing" crm-mosaico-ctrl="mosaicoCtrl"></div>
+        <div crm-mosaico-block-design crm-mailing="mailing" crm-mailing-attachments="attachments" crm-mosaico-ctrl="mosaicoCtrl"></div>
       </div>
 
       <div crmb-wizard-step crm-title="ts('Options')" ng-form="optionsForm">

--- a/ang/crmMosaico/EditMailingCtrl/bootstrap-wizard.html
+++ b/ang/crmMosaico/EditMailingCtrl/bootstrap-wizard.html
@@ -21,30 +21,30 @@
       </div>
 
       <button class="btn btn-secondary-outline" crmb-wizard-button-position="left" ng-click="crmbWizardCtrl.previous()" ng-show="!crmbWizardCtrl.$first()">
-      <span class="btn-icon"><i class="fa fa-chevron-left"></i></span>
-      {{ts('Back')}}
-    </button>
+        <span class="btn-icon"><i class="fa fa-chevron-left"></i></span>
+        {{ts('Back')}}
+      </button>
 
       <button class="btn btn-danger-outline" crmb-wizard-button-position="left" ng-show="checkPerm('delete in CiviMail') && crmbWizardCtrl.$first()" ng-disabled="block.check()" crm-confirm="{title:ts('Delete Draft'), message:ts('Are you sure you want to permanently delete this mailing?')}"
           on-yes="delete()">
-      <span class="btn-icon"><i class="fa fa-trash"></i></span>
-      {{ts('Delete Draft')}}
-    </button>
+        <span class="btn-icon"><i class="fa fa-trash"></i></span>
+        {{ts('Delete Draft')}}
+      </button>
 
       <button class="btn btn-secondary-outline" crmb-wizard-button-position="right" ng-disabled="block.check()" ng-click="save().then(leave)">
-      <span class="btn-icon"><i class="fa fa-floppy-o"></i></span>
-      {{ts('Save Draft')}}
-    </button>
+        <span class="btn-icon"><i class="fa fa-floppy-o"></i></span>
+        {{ts('Save Draft')}}
+      </button>
 
       <button class="btn btn-primary" crmb-wizard-button-position="right" title="{{!crmbWizardCtrl.$validStep() ? ts('Complete all required-mark fields first') : ts('Next step')}}" ng-click="crmbWizardCtrl.next()" ng-show="!crmbWizardCtrl.$last()" ng-disabled="!crmbWizardCtrl.$validStep()">
-      <span class="btn-icon"><i class="fa fa-chevron-right"></i></span>
-      {{ts('Continue')}}
-    </button>
+        <span class="btn-icon"><i class="fa fa-chevron-right"></i></span>
+        {{ts('Continue')}}
+      </button>
 
       <button class="btn btn-primary" crmb-wizard-button-position="right" ng-show="crmbWizardCtrl.$last()" ng-disabled="block.check() || !crmbWizardCtrl.$validStep()" ng-click="submit()">
-      <span class="btn-icon"><i class="fa fa-send"></i></span>
-      {{ts('Submit Mailing')}}
-    </button>
+        <span class="btn-icon"><i class="fa fa-send"></i></span>
+        {{ts('Submit Mailing')}}
+      </button>
 
     </div>
 

--- a/ang/crmMosaico/MixinCtrl.js
+++ b/ang/crmMosaico/MixinCtrl.js
@@ -2,99 +2,10 @@
 
   // This provides additional actions for editing a Mosaico mailing.
   // It coexists with crmMailing's EditMailingCtrl.
-  angular.module('crmMosaico').controller('CrmMosaicoMixinCtrl', function CrmMosaicoMixinCtrl($scope, dialogService, crmMosaicoTemplates, crmStatus, CrmMosaicoIframe, $timeout) {
+  angular.module('crmMosaico').controller('CrmMosaicoMixinCtrl', function CrmMosaicoMixinCtrl($scope, dialogService) {
     // var ts = $scope.ts = CRM.ts(null);
 
-    // Main data is in $scope.mailing, $scope.mosaicoCtrl.template
-
-    var crmMosaicoIframe = null, activeDialogs = {};
-
-    // Hrm, would like `ng-controller="CrmMosaicoMixinCtrl as mosaicoCtrl`, but that's not working...
-    $scope.mosaicoCtrl = {
-      templates: [],
-      // Fill a given "mailing" which the chosen "template".
-      select: function(mailing, template) {
-        var topt = mailing.template_options = mailing.template_options || {};
-        var promise = crmMosaicoTemplates.getFull(template).then(function(tplCtnt){
-          topt.mosaicoTemplate = template.id;
-          topt.mosaicoMetadata = tplCtnt.metadata;
-          topt.mosaicoContent = tplCtnt.content;
-          mailing.body_html = tplCtnt.html;
-          // console.log('select', {isAr1: _.isArray(mailing.template_options), isAr2: _.isArray(topt), m: mailing, t: template});
-          $scope.mosaicoCtrl.edit(mailing);
-        });
-        return crmStatus({start: ts('Loading...'), success: null}, promise);
-      },
-      // Figure out which "template" was previously used with a "mailing."
-      getTemplate: function(mailing) {
-        if (!mailing || !mailing.template_options || !mailing.template_options.mosaicoTemplate) {
-          return null;
-        }
-        var matches = _.where($scope.mosaicoCtrl.templates, {
-          id: mailing.template_options.mosaicoTemplate
-        });
-        return matches.length > 0 ? matches[0] : null;
-      },
-      // Reset all Mosaico data in a "mailing'.
-      reset: function(mailing) {
-        if (crmMosaicoIframe) crmMosaicoIframe.destroy();
-        crmMosaicoIframe = null;
-        delete mailing.template_options.mosaicoTemplate;
-        delete mailing.template_options.mosaicoMetadata;
-        delete mailing.template_options.mosaicoContent;
-        mailing.body_html = '';
-      },
-      // Edit a mailing in Mosaico.
-      edit: function(mailing) {
-        if (crmMosaicoIframe) {
-          crmMosaicoIframe.show();
-          return;
-        }
-
-        function syncModel(viewModel) {
-          mailing.body_html = viewModel.exportHTML();
-          mailing.template_options = mailing.template_options || {};
-          // Mosaico exports JSON. Keep their original encoding... or else the loader throws an error.
-          mailing.template_options.mosaicoMetadata = viewModel.exportMetadata();
-          mailing.template_options.mosaicoContent = viewModel.exportJSON();
-        }
-
-        crmMosaicoIframe = new CrmMosaicoIframe({
-          model: {
-            template: $scope.mosaicoCtrl.getTemplate(mailing).path,
-            metadata: mailing.template_options.mosaicoMetadata,
-            content: mailing.template_options.mosaicoContent
-          },
-          actions: {
-            sync: function(ko, viewModel) {
-              syncModel(viewModel);
-            },
-            close: function(ko, viewModel) {
-              viewModel.metadata.changed = Date.now();
-              syncModel(viewModel);
-              // TODO: When autosave is better integrated, remove this.
-              $timeout(function(){$scope.save();}, 100);
-              crmMosaicoIframe.hide('crmMosaicoEditorDialog');
-            },
-            test: function(ko, viewModel) {
-              syncModel(viewModel);
-
-              var model = {mailing: $scope.mailing, attachments: $scope.attachments};
-              var options = CRM.utils.adjustDialogDefaults(angular.extend(
-                {autoOpen: false, title: ts('Preview / Test'), width: 550},
-                options
-              ));
-              activeDialogs.crmMosaicoPreviewDialog = 1;
-              var pr = dialogService.open('crmMosaicoPreviewDialog', '~/crmMosaico/PreviewDialogCtrl.html', model, options)
-                .finally(function(){ delete activeDialogs.crmMosaicoPreviewDialog; });
-              return pr;
-            }
-          }
-        });
-
-        return crmStatus({start: ts('Loading...'), success: null}, crmMosaicoIframe.open());
-      }
-    };
+    var activeDialogs = {};
 
     // Open a dialog of advanced options.
     $scope.openAdvancedOptions = function() {
@@ -113,21 +24,10 @@
         .finally(function(){ delete activeDialogs.crmMosaicoAdvancedDialog; });
     };
 
-    crmMosaicoTemplates.whenLoaded().then(function(){
-      $scope.mosaicoCtrl.templates = crmMosaicoTemplates.getAll();
-      $scope.mosaicoCtrl.categoryFilters = _.transform(crmMosaicoTemplates.getCategories(), function(filters, category) {
-        filters.push({id: filters.length, text: category.label, filter: {category_id: category.value}});
-      }, [{id: 0, text: ts('Base Template'), filter: {isBase: true}}]);
-    });
-
     $scope.$on("$destroy", function() {
       angular.forEach(activeDialogs, function(v,name){
         dialogService.cancel(name);
       });
-      if (crmMosaicoIframe) {
-        crmMosaicoIframe.destroy();
-        crmMosaicoIframe = null;
-      }
     });
 
   });

--- a/ang/crmMosaico/MixinCtrl.js
+++ b/ang/crmMosaico/MixinCtrl.js
@@ -2,8 +2,29 @@
 
   // This provides additional actions for editing a Mosaico mailing.
   // It coexists with crmMailing's EditMailingCtrl.
-  angular.module('crmMosaico').controller('CrmMosaicoMixinCtrl', function CrmMosaicoMixinCtrl($scope, dialogService) {
-    // var ts = $scope.ts = CRM.ts(null);
+  angular.module('crmMosaico').controller('CrmMosaicoMixinCtrl', function CrmMosaicoMixinCtrl($scope, dialogService, crmMosaicoVariants) {
+    const ts = $scope.ts = CRM.ts('mosaico');
+
+    const singleDesign = [
+      {title: ts('Design'), vid: null, action: 'split'}
+    ];
+    const abDesign = [
+      {title: ts('Design (A)'), vid: 0, action: 'unsplit'},
+      {title: ts('Design (B)'), vid: 1, action: 'unsplit'},
+    ];
+
+    $scope.getDesigns = function(mailing) {
+      if (!mailing) return [];
+      return crmMosaicoVariants.isSplit(mailing, 'body_html') ? abDesign : singleDesign;
+    }
+    $scope.unsplitDesign = function(mailing, vid) {
+      crmMosaicoVariants.remove(mailing, ['mosaicoTemplate', 'mosaicoMetadata', 'mosaicoContent', 'body_html'], vid);
+    };
+    $scope.splitDesign = function(mailing) {
+      crmMosaicoVariants.split(mailing, ['mosaicoTemplate', 'mosaicoMetadata', 'mosaicoContent', 'body_html']);
+    };
+
+    $scope.isMailingSplit = (mailing, field) => crmMosaicoVariants.isSplit(mailing, field);
 
     var activeDialogs = {};
 

--- a/ang/crmMosaico/PreviewDialogCtrl.html
+++ b/ang/crmMosaico/PreviewDialogCtrl.html
@@ -1,5 +1,5 @@
 <div id='bootstrap-theme'>
   <div ng-controller="CrmMosaicoPreviewDialogCtrl" class="crm-mosaico-page">
-    <div crm-mosaico-block-preview crm-mailing="model.mailing" on-preview="previewMailing(model.mailing, preview.mode)" on-send="sendTest(model.mailing, model.attachments, preview.recipient)"></div>
+    <div crm-mosaico-block-preview crm-mailing="model.mailing" on-preview="previewMailing(model.mailing, model.variantId, preview.mode)" on-send="sendTest(model.mailing, model.variantId, model.attachments, preview.recipient)"></div>
   </div>
 </div>

--- a/ang/crmMosaico/PreviewDialogCtrl.js
+++ b/ang/crmMosaico/PreviewDialogCtrl.js
@@ -5,17 +5,18 @@
   //   - [input] "model": Object
   //     - "mailing": Object, CiviMail mailing
   //     - "attachments": Object, CrmAttachment
-  angular.module('crmMosaico').controller('CrmMosaicoPreviewDialogCtrl', function CrmMosaicoPreviewDialogCtrl($scope, crmMailingMgr, crmMailingPreviewMgr, crmBlocker, crmStatus) {
+  angular.module('crmMosaico').controller('CrmMosaicoPreviewDialogCtrl', function CrmMosaicoPreviewDialogCtrl($scope, crmMailingMgr, crmMailingPreviewMgr, crmBlocker, crmStatus, crmMosaicoVariants) {
     var ts = $scope.ts = CRM.ts(null);
     var block = $scope.block = crmBlocker();
 
     // @return Promise
-    $scope.previewMailing = function previewMailing(mailing, mode) {
-      return crmMailingPreviewMgr.preview(mailing, mode);
+    $scope.previewMailing = function previewMailing(mailing, variantId, mode) {
+      const preview = crmMosaicoVariants.preview(mailing, variantId);
+      return crmMailingPreviewMgr.preview(preview, mode);
     };
 
     // @return Promise
-    $scope.sendTest = function sendTest(mailing, attachments, recipient) {
+    $scope.sendTest = function sendTest(mailing, variantId, attachments, recipient) {
       var savePromise = crmMailingMgr.save(mailing)
         .then(function() {
           return attachments.save();

--- a/ang/crmMosaico/SubjectList.html
+++ b/ang/crmMosaico/SubjectList.html
@@ -1,4 +1,4 @@
-<div class="form-inline" ng-if="!mailing.template_options.variants">
+<div class="form-inline" ng-if="!isSplit()">
 
   <div class="from-group">
     <input
@@ -22,7 +22,7 @@
 
 </div>
 
-<div class="form-inline" ng-if="!!mailing.template_options.variants">
+<div class="form-inline" ng-if="isSplit()">
   <div class="group" ng-repeat="(vid, variant) in mailing.template_options.variants">
     ({{labels[vid]}})
 

--- a/ang/crmMosaico/SubjectList.js
+++ b/ang/crmMosaico/SubjectList.js
@@ -14,7 +14,7 @@
         scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
         scope.checkPerm = CRM.checkPerm;
 
-        scope.addSubj = () => crmMosaicoVariants.add(scope.mailing, 'subject');
+        scope.addSubj = () => crmMosaicoVariants.split(scope.mailing, 'subject');
         scope.rmSubj = (vid) => crmMosaicoVariants.remove(scope.mailing, 'subject', vid);
         scope.isSplit = () => crmMosaicoVariants.isSplit(scope.mailing, 'subject');
         scope.labels = crmMosaicoVariants.getLabels();

--- a/ang/crmMosaico/SubjectList.js
+++ b/ang/crmMosaico/SubjectList.js
@@ -1,6 +1,6 @@
 (function(angular, $, _) {
   // Example usage: <crm-mosaico-subject-list crm-mailing="myMailing" />
-  angular.module('crmMosaico').directive('crmMosaicoSubjectList', function(crmUiHelp) {
+  angular.module('crmMosaico').directive('crmMosaicoSubjectList', function(crmUiHelp, crmMosaicoVariants) {
     return {
       scope: {
         crmMailing: '@'
@@ -14,23 +14,10 @@
         scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
         scope.checkPerm = CRM.checkPerm;
 
-        scope.addSubj = function addSubj() {
-          scope.mailing.template_options.variants = [
-            {subject: scope.mailing.subject},
-            {subject: scope.mailing.subject}
-          ]
-        };
-
-        scope.rmSubj = function rmSubj(vid) {
-          var m = scope.mailing;
-          m.template_options.variants.splice(vid, 1);
-          if (m.template_options.variants.length === 1) {
-            m.subject = m.template_options.variants[0].subject;
-            delete m.template_options.variants;
-          }
-        };
-
-        scope.labels = ['A', 'B'];
+        scope.addSubj = () => crmMosaicoVariants.add(scope.mailing, 'subject');
+        scope.rmSubj = (vid) => crmMosaicoVariants.remove(scope.mailing, 'subject', vid);
+        scope.isSplit = () => crmMosaicoVariants.isSplit(scope.mailing, 'subject');
+        scope.labels = crmMosaicoVariants.getLabels();
       }
     };
 

--- a/ang/crmMosaico/Variants.js
+++ b/ang/crmMosaico/Variants.js
@@ -1,0 +1,48 @@
+(function(angular, $, _) {
+  angular.module('crmMosaico').service('crmMosaicoVariants', function() {
+    // This utility helps you manipulate the `variants` on a mailing.
+
+    function angularObj(obj) {
+      return JSON.parse(angular.toJson(obj));
+    }
+
+    return {
+      getLabels: () => ['A', 'B'],
+
+      // Enable variations for a particular field
+      // Ex: crmMosaicoVariants.addVariation(mymailing, 'subject')
+      add: function add(mailing, field) {
+        mailing.template_options.variants = mailing.template_options.variants || [];
+        for (var vid = 0; vid < 2; vid++) {
+          mailing.template_options.variants[vid] = mailing.template_options.variants[vid] || {};
+          mailing.template_options.variants[vid][field] = mailing[field];
+        }
+      },
+
+      // Disable variations for a particular field. Remove a particular record.
+      // Ex: crmMosaicoVariants.removeVariation(mymailing, 'subject', 1)
+      remove: function remove(mailing, field, badVid) {
+        delete mailing.template_options.variants[badVid][field];
+
+        // If there's only one value of `field`, then move it to top.
+        const remainders = _.filter(mailing.template_options.variants, (v) => v[field] !== undefined);
+        if (remainders.length === 1) {
+          mailing[field] = remainders[0][field];
+          for (var delVid = 0; delVid < 2; delVid++) {
+            delete mailing.template_options.variants[delVid][field];
+          }
+        }
+
+        // If the variants are empty, then delete the variant objects
+        const nonEmpties = _.filter(mailing.template_options.variants, (v) => !_.isEmpty(angularObj(v)));
+        if (nonEmpties.length === 0) {
+          delete mailing.template_options.variants;
+        }
+      },
+
+      isSplit: function isSplit(mailing, field) {
+        return mailing.template_options && mailing.template_options.variants && (field in mailing.template_options.variants[0]);
+      }
+    };
+  });
+})(angular, CRM.$, CRM._);

--- a/ang/crmMosaico/Variants.js
+++ b/ang/crmMosaico/Variants.js
@@ -73,8 +73,17 @@
         return preview;
       },
 
+      // isSplit(mailing): Determine if there are -any- split/variant fields.
+      // isSplit(mailing, field): Determine if a -specific- field has variations.
       isSplit: function isSplit(mailing, field) {
-        return mailing.template_options && mailing.template_options.variants && (field in mailing.template_options.variants[0]);
+        if (!mailing.template_options || !mailing.template_options.variants) {
+          return false;
+        }
+        if (field) {
+          return (field in mailing.template_options.variants[0]);
+        }
+        const nonEmpties = _.filter(mailing.template_options.variants, (v) => !_.isEmpty(angularObj(v)));
+        return nonEmpties.length > 0;
       }
     };
     return self;

--- a/ang/crmMosaico/Variants.js
+++ b/ang/crmMosaico/Variants.js
@@ -59,6 +59,20 @@
         }
       },
 
+      // Create a new, flat `mailing` record which includes overrides for a specific variant.
+      preview: function preview(mailing, vid) {
+        const preview = angular.copy(mailing, {}, 5);
+        if (vid !== null && vid !== undefined) {
+          angular.extend(preview, mailing.template_options.variants[vid]);
+        }
+        delete preview.id;
+        delete preview.template_options.variants;
+        delete preview.mosaicoTemplate;
+        delete preview.mosaicoMetadata;
+        delete preview.mosaicoContent;
+        return preview;
+      },
+
       isSplit: function isSplit(mailing, field) {
         return mailing.template_options && mailing.template_options.variants && (field in mailing.template_options.variants[0]);
       }


### PR DESCRIPTION
# Overview

Expands support for A/B testing.

~~This is currently marked "Draft" because there are a couple TODOs (noted at bottom of PR). However, it should work well enough that one can do some testing.~~ (*Resolved*)

ping @kurund 

# Before

* You may add a second "Subject" field, which enables A/B testing. (By default, it copies your current subject.)

# After

* You may add a second "Subject" field, which enables A/B testing. (By default, it copies your current subject.)
* You may add a second "Design" section, which enables A/B testing. (By default, it copies your current design.)

    <img width="817" alt="Screenshot 2024-02-01 at 10 32 08 PM" src="https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/assets/1336047/380b878c-8256-49c9-9521-bbba037c9546">

    After doing this, you will see "Design (A)" and "Design (B)".

    <img width="801" alt="Screenshot 2024-02-01 at 10 28 56 PM" src="https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/assets/1336047/ab168f13-4858-4c93-bcae-b7f09c721353">

* It is possible to mix/match testing at the "Subject"-level and the "Design"-level.  The GUI provides separate options for enabling/disabling each of these. These should be working in both "Single Page" and "Wizard" layouts.

* (Aside: I moved the "A/B testing" percentage-sliders toward the end of the "New Mailing" screen. When there are multiple ways to enable A/B testing, it's a bit confusing if the sliders popup *earlier* in the UI. The new placement ensures that the sliders appear you've made all the decisions about whether to test subject and/or design.)

# Technical Details

Within a `Mailing` record, there is a section `template_options.variants[0,1]`. The existing `AbDemux` component reads this property and generates "A" and "B" mailings (if present). This is how the `subject`-testing works. This PR follows the same path for testing two values of `body_html`. The existing `AbDemuxTest` already has scenarios for [multiple `body_html` variants](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/blob/3.3/tests/phpunit/CRM/Mosaico/AbDemuxTest.php#L63-L66).

Here are a few examples of how the content ought to look:

<details><summary>Example: JSON for single subject and single design</summary>

```javascript
{
  id: 123,
  subject: "Apples are the best fruit",
  body_html: "<html>...yummy...</html>",
  template_options: {
    mosaicoTemplate: "basic-versafix-1",
    mosaicoMetadata: "{...}",
    mosaicoContent: "{...yummy...}"
  }
}
```

</details>

<details><summary>Example: JSON for dual subject and dual design</summary>

```javascript
{
  id: 123,
  subject: "PLACEHOLDER",
  body_html: "PLACEHOLDER",
  template_options: {
    variants: [
      {
        subject: "Apples are the best fruit",
        body_html: "<html>...yummy apple...</html>",
        mosaicoTemplate: "basic-versafix-1",
        mosaicoMetadata: "{...}",
        mosaicoContent: "{...yummy apple...}"
      },
      {
        subject: "Bananas are the best fruit",
        body_html: "<html>...yummy banana...</html>",
        mosaicoTemplate: "basic-versafix-1",
        mosaicoMetadata: "{...}",
        mosaicoContent: "{...yummy banana...}"
      }

    ]
  }
}
```

</details>

In comparing the examples, observe:

* If the `subject` is tested, then we move `subject` into `mailing.template_options.variants.[0,1].subject`.
* If the `body_html` (w/`mosaicoContent`, etc) is tested, then we move the `body_html` (w/`mosaicoContent`, etc) into `mailing.template_options.variants.[0,1].body_html`.

Most of the work in developing this PR has been about updating web UI to consistently populate+cleanup the data in `template_options.variants` (based on whether the user activates `subject` and/or `body_html` variations).

# TODO

* ~~When you use editor, there are options to "Preview" (in browser) or "Send test" (via email). This is basically working for "Send test" (*but not stress-tested yet*). However, the "Preview" is not yet working.~~
* ~~Submit a mailing and try out the full flow of two blasts (followed by third/final blast).~~