### PR TITLE
fix civicrmtoken when mosaicoConfig hook is used

### DIFF
--- a/CRM/Mosaico/Page/Editor.php
+++ b/CRM/Mosaico/Page/Editor.php
@@ -93,6 +93,9 @@ class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
         'browser_spellcheck' => TRUE,
       ],
       'tinymceConfigFull' => [
+        'external_plugins' => [
+          'civicrmtoken' => $res->getUrl('uk.co.vedaconsulting.mosaico', 'js/tinymce-plugins/civicrmtoken/plugin.js', 1),
+        ],
         'plugins' => ['link hr paste lists textcolor code civicrmtoken'],
         'toolbar1' => 'bold italic forecolor backcolor hr bullist styleselect removeformat | civicrmtoken | link unlink | pastetext code',
       ],


### PR DESCRIPTION
When using an extension that uses `hook_civicrm_mosaicoConfig` I would get this error:

![image](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/assets/1796012/127b051e-0e1b-4e10-a9aa-c4085124c6f3)

```
Failed to load plugin: civicrmtoken from url https://mysite.org/sites/all/civicrm-custom/extensions/uk.co.vedaconsulting.mosaico/packages/mosaico/dist/rs/plugins/civicrmtoken/plugin.min.js
```

I thought that `tinymceConfigFull`  was supposed to inherit `tinymceConfig` - but perhaps that happens differently when the hook is invoked.  At any rate, I found that explicitly defining the path to `civicrmtoken` fixed the issue.