### PR TITLE
Add A/B testing for "From:" address

### DIFF
--- a/ang/crmMosaico/BlockMailing.html
+++ b/ang/crmMosaico/BlockMailing.html
@@ -28,18 +28,8 @@
 
   <div class="form-group" ng-show="crmMailingConst.enableReplyTo">
     <label for="inputReplyTo" class="control-label">{{ts('Reply-To')}}</label>
-    <div ng-controller="EmailAddrCtrl">
-      <select
-          id="inputReplyTo"
-          class="form-control"
-          crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Email address')}"
-          name="replyTo"
-          ng-change="checkReplyToChange(mailing)"
-          ng-model="mailing.replyto_email"
-      >
-        <option value=""></option>
-        <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'" value="{{frm.label}}">{{frm.label}}</option>
-      </select>
+    <div>
+      <crm-mosaico-reply-to-list crm-mailing="mailing" />
     </div>
   </div>
 

--- a/ang/crmMosaico/BlockMailing.html
+++ b/ang/crmMosaico/BlockMailing.html
@@ -21,18 +21,8 @@
   <div class="form-group">
     <label for="inputFrom" ng-class="checkPerm('create mailings') ? 'control-label' : 'control-label required-mark'">{{ts('From')}}
       <a crm-ui-help="hs({id: 'from_email', title: ts('From')})"></a></label>
-    <div ng-controller="EmailAddrCtrl" crm-mailing-from-address="fromPlaceholder" crm-mailing="mailing">
-      <select
-          id="inputFrom"
-          class="form-control"
-          crm-ui-select="{dropdownAutoWidth : true, allowClear: false}"
-          name="fromAddress"
-          ng-model="fromPlaceholder.label"
-          required>
-        <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'"
-                value="{{frm.label}}">{{frm.label}}
-        </option>
-      </select>
+    <div>
+      <crm-mosaico-from-list crm-mailing="mailing" />
     </div>
   </div>
 

--- a/ang/crmMosaico/FromList.html
+++ b/ang/crmMosaico/FromList.html
@@ -1,22 +1,18 @@
 <div class="form-inline" ng-if="!isSplit()">
   <div class="form-group">
     <span ng-controller="EmailAddrCtrl" crm-mailing-from-address="fromPlaceholder" crm-mailing="mailing">
-      <!--
-      For the following <select>, select2 would be nice. But width is weird in this context. Need CSS expert...
-      crm-ui-select="{dropdownAutoWidth : true, allowClear: false}"
-      -->
       <select
           id="inputFrom"
           class="form-control"
           name="fromAddress"
           ng-model="fromPlaceholder.label"
+          crm-ui-select="{width: '40em', dropdownAutoWidth : true, allowClear: false}"
           required>
         <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'"
                 value="{{frm.label}}">{{frm.label}}
         </option>
       </select>
     </span>
-
     <a ng-click="addFrom()" class="btn btn-default" title="{{ts('Add alternate \'From\'')}}">
       <span><i class="crm-i fa-plus-circle"></i></span>
     </a>
@@ -28,15 +24,12 @@
     ({{labels[vid]}})
 
     <span ng-controller="EmailAddrCtrl" crm-mailing-from-address="fromPlaceholder" crm-mailing="variant">
-      <!--
-      For the following <select>, select2 would be nice. But width is weird in this context. Need CSS expert...
-      crm-ui-select="{dropdownAutoWidth : true, allowClear: false}"
-      -->
       <select
         crm-ui-id="subform.from"
         name="fromAddressA"
         class="form-control"
         ng-model="fromPlaceholder.label"
+        crm-ui-select="{width: '40em', dropdownAutoWidth : true, allowClear: false}"
         required>
         <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'"
                 value="{{frm.label}}">{{frm.label}}

--- a/ang/crmMosaico/FromList.html
+++ b/ang/crmMosaico/FromList.html
@@ -1,0 +1,51 @@
+<div class="form-inline" ng-if="!isSplit()">
+  <div class="form-group">
+    <span ng-controller="EmailAddrCtrl" crm-mailing-from-address="fromPlaceholder" crm-mailing="mailing">
+      <!--
+      For the following <select>, select2 would be nice. But width is weird in this context. Need CSS expert...
+      crm-ui-select="{dropdownAutoWidth : true, allowClear: false}"
+      -->
+      <select
+          id="inputFrom"
+          class="form-control"
+          name="fromAddress"
+          ng-model="fromPlaceholder.label"
+          required>
+        <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'"
+                value="{{frm.label}}">{{frm.label}}
+        </option>
+      </select>
+    </span>
+
+    <a ng-click="addFrom()" class="btn btn-default" title="{{ts('Add alternate \'From\'')}}">
+      <span><i class="crm-i fa-plus-circle"></i></span>
+    </a>
+  </div>
+</div>
+
+<div class="form-inline" ng-if="isSplit()">
+  <div class="form-group" ng-repeat="(vid, variant) in mailing.template_options.variants">
+    ({{labels[vid]}})
+
+    <span ng-controller="EmailAddrCtrl" crm-mailing-from-address="fromPlaceholder" crm-mailing="variant">
+      <!--
+      For the following <select>, select2 would be nice. But width is weird in this context. Need CSS expert...
+      crm-ui-select="{dropdownAutoWidth : true, allowClear: false}"
+      -->
+      <select
+        crm-ui-id="subform.from"
+        name="fromAddressA"
+        class="form-control"
+        ng-model="fromPlaceholder.label"
+        required>
+        <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'"
+                value="{{frm.label}}">{{frm.label}}
+        </option>
+      </select>
+    </span>
+
+    <a ng-click="rmFrom(vid)" class="btn btn-default" title="{{ts('Remove alternate \'From\'')}}">
+      <span><i class="crm-i fa-trash"></i></span>
+    </a>
+  </div>
+</div>

--- a/ang/crmMosaico/FromList.js
+++ b/ang/crmMosaico/FromList.js
@@ -1,0 +1,42 @@
+(function(angular, $, _) {
+  // Example usage: <crm-mosaico-from-list crm-mailing="myMailing" />
+  angular.module('crmMosaico').directive('crmMosaicoFromList', function(crmUiHelp, crmMosaicoVariants) {
+    return {
+      scope: {
+        crmMailing: '@'
+      },
+      templateUrl: '~/crmMosaico/FromList.html',
+      link: function (scope, elm, attr) {
+        scope.$parent.$watch(attr.crmMailing, function(newValue){
+          scope.mailing = newValue;
+        });
+        scope.ts = CRM.ts(null);
+        scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
+        scope.checkPerm = CRM.checkPerm;
+
+        scope.addFrom = function() {
+          crmMosaicoVariants.split(scope.mailing, 'from_name');
+          crmMosaicoVariants.split(scope.mailing, 'from_email');
+          if (!CRM.crmMailing.enableReplyTo) {
+            // Ugh. Brain hurts. See also: crmMailingFromAddress (CRM-18364 behavior)
+            crmMosaicoVariants.split(scope.mailing, 'replyto_email');
+          }
+
+        }
+        scope.rmFrom = function(vid) {
+          crmMosaicoVariants.remove(scope.mailing, 'from_email', vid);
+          crmMosaicoVariants.remove(scope.mailing, 'from_name', vid);
+          if (!CRM.crmMailing.enableReplyTo) {
+            // Ugh. Brain hurts. See also: crmMailingFromAddress (CRM-18364 behavior)
+            crmMosaicoVariants.remove(scope.mailing, 'replyto_email', vid);
+          }
+        }
+        scope.isSplit = function() {
+          return crmMosaicoVariants.isSplit(scope.mailing, 'from_email')
+        }
+        scope.labels = crmMosaicoVariants.getLabels();
+      }
+    };
+
+  });
+})(angular, CRM.$, CRM._);

--- a/ang/crmMosaico/ReplyToList.html
+++ b/ang/crmMosaico/ReplyToList.html
@@ -1,0 +1,49 @@
+<div class="form-inline" ng-if="!isSplit()">
+  <div class="form-group">
+    <span ng-controller="EmailAddrCtrl">
+      <!--
+      crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Email address')}"
+      -->
+      <select
+        id="inputReplyTo"
+        class="form-control"
+        name="replyTo"
+        ng-change="checkReplyToChange(mailing)"
+        ng-model="mailing.replyto_email"
+      >
+        <option value="">(Email address)</option><!-- If you fix crm-ui-select, then this label can be emptied. It functions as placeholder text. -->
+        <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'" value="{{frm.label}}">{{frm.label}}</option>
+      </select>
+    </span>
+
+    <a ng-click="addReplyTo()" class="btn btn-default" title="{{ts('Add alternate \'Reply-To\'')}}">
+      <span><i class="crm-i fa-plus-circle"></i></span>
+    </a>
+  </div>
+</div>
+
+<div class="form-inline" ng-if="isSplit()">
+  <div class="form-group" ng-repeat="(vid, variant) in mailing.template_options.variants">
+    ({{labels[vid]}})
+
+    <span ng-controller="EmailAddrCtrl">
+      <!--
+      crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Email address')}"
+      -->
+      <select
+        id="inputReplyToA"
+        class="form-control"
+        name="replyToA"
+        ng-change="checkReplyToChange(variant)"
+        ng-model="variant.replyto_email"
+      >
+        <option value="">(Email address)</option><!-- If you fix crm-ui-select, then this label can be emptied. It functions as placeholder text. -->
+        <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'" value="{{frm.label}}">{{frm.label}}</option>
+      </select>
+    </span>
+
+    <a ng-click="rmReplyTo(vid)" class="btn btn-default" title="{{ts('Remove alternate \'Reply-To\'')}}">
+      <span><i class="crm-i fa-trash"></i></span>
+    </a>
+  </div>
+</div>

--- a/ang/crmMosaico/ReplyToList.html
+++ b/ang/crmMosaico/ReplyToList.html
@@ -1,15 +1,13 @@
 <div class="form-inline" ng-if="!isSplit()">
   <div class="form-group">
     <span ng-controller="EmailAddrCtrl">
-      <!--
-      crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Email address')}"
-      -->
       <select
         id="inputReplyTo"
         class="form-control"
         name="replyTo"
         ng-change="checkReplyToChange(mailing)"
         ng-model="mailing.replyto_email"
+        crm-ui-select="{width: '40em', dropdownAutoWidth : true, allowClear: true, placeholder: ts('Email address')}"
       >
         <option value="">(Email address)</option><!-- If you fix crm-ui-select, then this label can be emptied. It functions as placeholder text. -->
         <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'" value="{{frm.label}}">{{frm.label}}</option>
@@ -27,15 +25,13 @@
     ({{labels[vid]}})
 
     <span ng-controller="EmailAddrCtrl">
-      <!--
-      crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Email address')}"
-      -->
       <select
         id="inputReplyToA"
         class="form-control"
         name="replyToA"
         ng-change="checkReplyToChange(variant)"
         ng-model="variant.replyto_email"
+        crm-ui-select="{width: '40em', dropdownAutoWidth : true, allowClear: true, placeholder: ts('Email address')}"
       >
         <option value="">(Email address)</option><!-- If you fix crm-ui-select, then this label can be emptied. It functions as placeholder text. -->
         <option ng-repeat="frm in crmFromAddresses.getAll() | filter:{is_active:1} | orderBy:'weight'" value="{{frm.label}}">{{frm.label}}</option>

--- a/ang/crmMosaico/ReplyToList.js
+++ b/ang/crmMosaico/ReplyToList.js
@@ -1,0 +1,25 @@
+(function(angular, $, _) {
+  // Example usage: <crm-mosaico-reply-to-list crm-mailing="myMailing" />
+  angular.module('crmMosaico').directive('crmMosaicoReplyToList', function(crmUiHelp, crmMosaicoVariants) {
+    return {
+      scope: {
+        crmMailing: '@'
+      },
+      templateUrl: '~/crmMosaico/ReplyToList.html',
+      link: function (scope, elm, attr) {
+        scope.$parent.$watch(attr.crmMailing, function(newValue){
+          scope.mailing = newValue;
+        });
+        scope.ts = CRM.ts(null);
+        scope.hs = crmUiHelp({file: 'CRM/Mailing/MailingUI'});
+        scope.checkPerm = CRM.checkPerm;
+
+        scope.addReplyTo = () => crmMosaicoVariants.split(scope.mailing, 'replyto_email');
+        scope.rmReplyTo = (vid) => crmMosaicoVariants.remove(scope.mailing, 'replyto_email', vid);
+        scope.isSplit = () => crmMosaicoVariants.isSplit(scope.mailing, 'replyto_email');
+        scope.labels = crmMosaicoVariants.getLabels();
+      }
+    };
+
+  });
+})(angular, CRM.$, CRM._);

--- a/ang/crmMosaico/SubjectList.html
+++ b/ang/crmMosaico/SubjectList.html
@@ -14,7 +14,7 @@
 
     <input crm-mailing-token on-select="$broadcast('insert:subject', token.name)" tabindex="-1" class="form-control"/>
 
-    <a ng-click="addSubj()" class="btn btn-default" title="{{ts('Add subject')}}">
+    <a ng-click="addSubj()" class="btn btn-default" title="{{ts('Add alternate \'Subject\'')}}">
       <span><i class="crm-i fa-plus-circle"></i></span>
     </a>
 
@@ -39,7 +39,7 @@
 
     <input crm-mailing-token on-select="$broadcast('insert:subject', token.name)" tabindex="-1" class="form-control"/>
 
-    <a ng-click="rmSubj(vid)" class="btn btn-default" title="{{ts('Remove subject')}}">
+    <a ng-click="rmSubj(vid)" class="btn btn-default" title="{{ts('Remove alternate \'Subject\'')}}">
       <span><i class="crm-i fa-trash"></i></span>
     </a>
 

--- a/ang/crmMosaico/Variants.js
+++ b/ang/crmMosaico/Variants.js
@@ -9,6 +9,9 @@
     const mainPlaceholders = {
       subject: 'VARIANT SUBJECTS',
       body_html: 'VARIANT HTMLS',
+      from_name: 'VARIANT FROM',
+      from_email: 'VARIANT@EXAMPLE.ORG',
+      replyto_email: '"VARIANT FROM" <VARIANT@EXAMPLE.ORG>',
       mosaicoTemplate: "",
       mosaicoMetadata: '{}',
       mosaicoContent: '{}'

--- a/ang/crmMosaico/Variants.js
+++ b/ang/crmMosaico/Variants.js
@@ -6,7 +6,13 @@
       return JSON.parse(angular.toJson(obj));
     }
 
-    const mainPlaceholders = {subject: 'VARIANT SUBJECTS', body_html: 'VARIANT HTMLS', mosaicoTemplate: "", mosaicoMetadata: '{}', mosaicoContent: '{}'};
+    const mainPlaceholders = {
+      subject: 'VARIANT SUBJECTS',
+      body_html: 'VARIANT HTMLS',
+      mosaicoTemplate: "",
+      mosaicoMetadata: '{}',
+      mosaicoContent: '{}'
+    };
 
     const self = {
       getLabels: () => ['A', 'B'],

--- a/tests/phpunit/CRM/Mosaico/AbDemuxTest.php
+++ b/tests/phpunit/CRM/Mosaico/AbDemuxTest.php
@@ -65,6 +65,12 @@ class CRM_Mosaico_AbDemuxTest extends CRM_Mosaico_TestCase implements \Civi\Test
       ['subject' => 'New Subject A', 'body_html' => 'New Html A'],
       ['subject' => 'New Subject B', 'body_html' => 'New Html B'],
     ];
+    $cases[] = [
+      ['from_email' => 'albert@example.org', 'from_name' => 'Albert Albertson', 'subject' => 'Subject A'],
+      ['from_email' => 'albert@example.org', 'from_name' => 'Barb Barbagelata', 'subject' => 'Subject B'],
+      ['from_email' => 'albert@example.org', 'from_name' => 'Albert Albertson', 'subject' => 'Subject A'],
+      ['from_email' => 'albert@example.org', 'from_name' => 'Barb Barbagelata', 'subject' => 'Subject B'],
+    ];
 
     return $cases;
   }


### PR DESCRIPTION
# Overview

Expands support for A/B testing.

ping @kurund

# Before

* You may add an alternate "Subject" and/or "Design". This enables A/B testing. (By default, it copies your current subject/design.)

# After

* You may add an alternate  "From", "Subject", and/or "Design". This enables A/B testing. (By default, it copies your current subject/design.)

* The "New Mailing" screen starts with one "From" field:
    <img width="664" alt="Screenshot 2024-04-30 at 4 43 01 PM" src="https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/assets/1336047/f98f24d4-ecad-429e-b494-7ae6038d5fe2">
* If you click "+", it adds another "From" field:
    <img width="659" alt="Screenshot 2024-04-30 at 4 42 49 PM" src="https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/assets/1336047/27de292e-e54d-4eb0-8ce7-b9a7dbb639c3">

# Comments

In my `r-run`, it does generate messages with the alternate "From" addresses. (This is expected, given that `AbDemux` anticipates variations on these fields. I added a bit more coverage in `AbDemuxTest` to show this.)

Here are a couple issues to review/consider before merging....

1. __Select2 Widget__: 
    * The "From" widget was previously declared with select2 (`crm-ui-select="{dropdownAutoWidth : true, allowClear: false}"`).
    * But I'm finding it hard to figure out markup which meets all these goals: (a) be simple/standard, (b) render with a reasonable width, (c) display the dropdown alongside the "+" button, and (d) use `select2`.
    * For the moment, I've got it using a standard `<select>`, which satisfies (a)+(b)+(c) but not (d).
    * Probably someone with more select2/css experience could make select2 work. 
2. __Reply-To Edge-Cases__:
    * Each `Mailing` record has three related fields. Typical values look like this:
        ```javascript
       {
         "from_name": "Albert Albertson",
         "from_email": "albert@example.org",
         "replyto_email": "\"Albert Albertson\" <albert@example.org>",
       }
        ```
    * This data-model is weird. The pre-existing web UI hides the weirdness in a couple ways. First, it simulates a single UI widget ("From") based on two API fields (`from_name`,`from_email`). Second, it may autofill `replyto_email`... but it depends on a configuration option (`enableReplyTo` aka `replyTo`):
        * If `replyTo` is enabled, then it displays "Reply-To" as a separate field (*independent of "From"*).
        * If `replyTo` is disabled, then it quietly autofills `replyto_email` based on `from_name`/`from_email`.
    * This patch *should* preserve these behaviors, as long as the setting `enableReplyTo` remains static (*which would be true in normal/day-to-day usage*).
    * However, if you allow `replyTo` to get reconfigured, then existing data may get pulled into some funny edge-case. (*Ex: Create a mailing; split the "From" values; save draft; change the setting; resume editing.*) I have not tested these edges. _Guess_: Some would feel OK; others would feel wrong (esp when the `variants` defines 2x `replyto_email` values, but the UI wants to show one "Reply-To" widget);
    *  I think there are a few options, but I'm not a big fan of any of them.
        * Leave be. It'll work in normal usage.
        * Add A/B support for the "Reply-To" field (for systems with `enableReplyTo=true`). More verbose code. Not a feature anyone particularly asked for. But probably the best functionality.
        * Move all responsibility for sync'ing `replyto_email`<=>`from_name+from_email` to a different layer. (Only sync when you submit.) Eventual code should still be concise. (*But it feels a bit more risky -- I suspect there's some reason why it was put in its current spot.*)
    * The lazy part of me likes the first option more. The maintainer part of me likes the second option more.