### PR TITLE
Update composer.json, add type:civicrm-ext to allow the Mosaico extension to be installed via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "civipkg/uk.co.vedaconsulting.mosaico",
+  "type": "civicrm-ext",
   "require": {
     "intervention/image": "^2.4",
     "civicrm/composer-downloads-plugin": "^3.0 || ^4.0"


### PR DESCRIPTION
This adds `"type": "civicrm-ext"` to the `composer.json` file to allow the extension to be installed on CiviCRM installations via Composer, with the extension ending up in the correct extensions directory.

This follows a recent blog post I've written on the topic, which goes into more detail about why this is useful: https://civicrm.org/blog/bradleyt/composer-installers-and-civicrm