### PR TITLE
Remove composer.json replaced packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,6 @@
     "intervention/image": "^2.4",
     "civicrm/composer-downloads-plugin": "^3.0 || ^4.0"
   },
-  "replace": {
-    "guzzlehttp/guzzle": "^6.5 || ^7.0",
-    "guzzlehttp/psr7": "^1.8.5"
-  },
   "config": {
     "allow-plugins": {
       "civicrm/composer-downloads-plugin": true


### PR DESCRIPTION
In the composer.json there are currently 2 packages marked as replaced:
- guzzlehttp/guzzle ^6.5 || ^7.0
- guzzlehttp/psr7 ^1.8.5

These aren't actually replaced by this extension and are presumably included here as they can be assumed to be provided elsewhere in the civicrm installation, however this can cause conflicts when other requirements conflict with specific versions (e.g. roave/security-advisories conflicts with guzzlehttp/guzzle <6.5.8|>=7,<7.4.5)