### PR TITLE
#664 - Fix duplicate contact creation when sending a test to multiple emails when there's a space after the comma

### DIFF
--- a/ang/crmMosaico/BlockPreview.js
+++ b/ang/crmMosaico/BlockPreview.js
@@ -33,8 +33,9 @@
           });
         };
         scope.doSend = function doSend(recipient) {
+          var trimmed = recipient.email.replace(/\s/, '');
           scope.$eval(attr.onSend, {
-            preview: {recipient: recipient}
+            preview: {recipient: {email: trimmed}}
           });
         };
 


### PR DESCRIPTION
Overview
---------
Addresses https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/issues/664

Before
-------
1. In the email editor click the Test button.
2. In the send test email field enter two emails that belong to contacts and put a space after the comma, e.g. `person1@org1.org, person2@org2.org`
3. Person2 will receive the email but a duplicate contact is created.

After
-----
No duplicate contact created.