### PR TITLE
Fix for issue #567 - Civi cannot handle Drupal multilanguage path, so cannot find template url

### DIFF
--- a/api/v3/MosaicoTemplate.php
+++ b/api/v3/MosaicoTemplate.php
@@ -73,12 +73,10 @@ function civicrm_api3_mosaico_template_get($params) {
     $metaData = json_decode($getresult['values'][0]['metadata'], TRUE);
     $baseTemplateURL = $metaData['template'];
 
-    $baseURL = CRM_Utils_System::baseURL();
-
     if (_civicrm_api3_mosaico_template_getDomainFrom($baseTemplateURL)) {
       $urlParts = parse_url($baseTemplateURL);
       $templatePath = $urlParts['path'];
-      $currentURL = CRM_Utils_System::baseURL() . $templatePath;
+      $currentURL =  \Civi::paths()->getVariable('cms.root', 'url') . $templatePath;
     } else {
       $currentURL = $baseTemplateURL;
     }


### PR DESCRIPTION
Alternative for https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/pull/629

