### PR TITLE
Ensure that Flexmailer does not re-trigger the processing in onCompose

### DIFF
--- a/CRM/Mosaico/MosaicoComposer.php
+++ b/CRM/Mosaico/MosaicoComposer.php
@@ -14,6 +14,17 @@ class CRM_Mosaico_MosaicoComposer extends \Civi\FlexMailer\Listener\DefaultCompo
     return $mailing->template_type === 'mosaico';
   }
 
+  public function onCompose(
+    \Civi\FlexMailer\Event\ComposeBatchEvent $e
+  ) {
+    if (!$this->isActive() || !$this->isSupported($e->getMailing())) {
+      return;
+    }
+    parent::onCompose($e);
+    // Disable the processing in the parent onCompose function now that we have processed it already
+    \Civi::service('civi_flexmailer_default_composer')->setActive(FALSE);
+  }
+
   public function createTokenProcessorContext(
     \Civi\FlexMailer\Event\ComposeBatchEvent $e
   ) {


### PR DESCRIPTION
@mattwire 

This should be fine because I believe the weighting here https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/blob/2.x/CRM/Mosaico/Services.php#L41 compared to https://github.com/civicrm/civicrm-core/blob/master/ext/flexmailer/src/Services.php#L64 means that I think Mosaico runs first so we can disable flexmailer's re-processing at least