### PR TITLE
resolve #677 by applying a patch using composer patches to fix deprec…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
   "type": "civicrm-ext",
   "require": {
     "intervention/image": "^2.4",
-    "civicrm/composer-downloads-plugin": "^3.0 || ^4.0"
+    "civicrm/composer-downloads-plugin": "^3.0 || ^4.0",
+    "cweagans/composer-patches": "~1.0"
   },
   "replace": {
     "guzzlehttp/guzzle": "^6.5 || ^7.0",
@@ -11,7 +12,8 @@
   },
   "config": {
     "allow-plugins": {
-      "civicrm/composer-downloads-plugin": true
+      "civicrm/composer-downloads-plugin": true,
+      "cweagans/composer-patches": true
     }
   },
   "extra": {
@@ -20,6 +22,11 @@
         "version": "v0.18.10-civicrm-4.0",
         "path": "packages/mosaico",
         "url": "https://github.com/civicrm/mosaico/releases/download/{$version}/mosaico-dist.tar.gz"
+      }
+    },
+    "patches": {
+      "intervention/image": {
+        "Apply patch to fix deprecation notice in gd imagepolygon and imagefilledpolygon": "./patches/gd_deprecation_notice_fix_for_imagefilledpolygon.patch"
       }
     }
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7416094f545ccbeba89a2ba8eab53a2",
+    "content-hash": "f0c1cdad72e767fb4bd161ff5d668f8e",
     "packages": [
         {
             "name": "civicrm/composer-downloads-plugin",
@@ -100,6 +100,54 @@
             "time": "2024-04-09T07:07:33+00:00"
         },
         {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+            },
+            "time": "2022-12-20T22:53:13+00:00"
+        },
+        {
             "name": "intervention/image",
             "version": "2.7.2",
             "source": {
@@ -187,10 +235,10 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/patches/gd_deprecation_notice_fix_for_imagefilledpolygon.patch
+++ b/patches/gd_deprecation_notice_fix_for_imagefilledpolygon.patch
@@ -1,0 +1,17 @@
+--- src/Intervention/Image/Gd/Shapes/PolygonShape.php	2025-07-09 09:29:58.026270951 +1000
++++ src/Intervention/Image/Gd/Shapes/PolygonShape.php	2025-07-09 09:30:34.940638065 +1000
+@@ -36,12 +36,12 @@
+     public function applyToImage(Image $image, $x = 0, $y = 0)
+     {
+         $background = new Color($this->background);
+-        imagefilledpolygon($image->getCore(), $this->points, intval(count($this->points) / 2), $background->getInt());
++        imagefilledpolygon($image->getCore(), $this->points, $background->getInt());
+         
+         if ($this->hasBorder()) {
+             $border_color = new Color($this->border_color);
+             imagesetthickness($image->getCore(), $this->border_width);
+-            imagepolygon($image->getCore(), $this->points, intval(count($this->points) / 2), $border_color->getInt());
++            imagepolygon($image->getCore(), $this->points, $border_color->getInt());
+         }
+     
+         return true;


### PR DESCRIPTION
…ation notices on php8.1

It seems that the upstream library isn't doing any further commits on the 2.x branch there is a 3.x branch but that needs a minimum of PHP8.1 which is higher than CiviCore's minum and a simple patch here should be fine based on the documentation here https://www.php.net/manual/en/function.imagefilledpolygon.php https://www.php.net/manual/en/function.imagepolygon.php and that CiviCRM Core's min PHP in 6.0 is 8.0