### PR TITLE
For A/B content mailing, copy template_options so usable copies can be made

### DIFF
--- a/CRM/Mosaico/AbDemux.php
+++ b/CRM/Mosaico/AbDemux.php
@@ -55,6 +55,9 @@ class CRM_Mosaico_AbDemux {
     'unsubscribe_id',
     'resubscribe_id',
     'optout_id',
+    'mosaicoTemplate',
+    'mosaicoMetadata',
+    'mosaicoContent',
   ];
 
   /**
@@ -231,14 +234,22 @@ class CRM_Mosaico_AbDemux {
    */
   protected function applyVariant(&$mailing, $variant) {
     $overrides = array_intersect(array_keys($variant), $this->variantFields);
+    $templateOptions = ['mosaicoTemplate', 'mosaicoMetadata', 'mosaicoContent'];
     if (is_array($mailing)) {
       foreach ($overrides as $override) {
-        $mailing[$override] = $variant[$override];
+        if (in_array($override, $templateOptions)) {
+          $mailing['template_options'][$override] = $variant[$override];
+        }
+        else {
+          $mailing[$override] = $variant[$override];
+        }
       }
     }
     elseif (is_object($mailing)) {
       foreach ($overrides as $override) {
-        $mailing->{$override} = $variant[$override];
+        if (!(in_array($override, $templateOptions))) {
+          $mailing->{$override} = $variant[$override];
+        }
       }
     }
     else {


### PR DESCRIPTION
Before
----------------------------------------
If you create a copy of a mailing that was sent as part of an A/B content test, you cannot edit that mailing because template_options does not contain the Mosaico data.

After
----------------------------------------
Copies can be edited as usual.

Comments
----------------------------------------
We don't need the template options if the mailing is an object, because that's just for sending tests.