### PR TITLE
avoid consecutive slashes in metadata template URL - fixes issue #692

### DIFF
--- a/api/v3/MosaicoTemplate.php
+++ b/api/v3/MosaicoTemplate.php
@@ -76,7 +76,8 @@ function civicrm_api3_mosaico_template_get($params) {
     if (_civicrm_api3_mosaico_template_getDomainFrom($baseTemplateURL)) {
       $urlParts = parse_url($baseTemplateURL);
       $templatePath = $urlParts['path'];
-      $currentURL =  \Civi::paths()->getVariable('cms.root', 'url') . '/' . $templatePath;
+      $currentURL = rtrim(\Civi::paths()->getVariable('cms.root', 'url'), "/") .
+                    '/' . ltrim($templatePath,'/');
     } else {
       $currentURL = $baseTemplateURL;
     }


### PR DESCRIPTION
This PR aims to consider pre-existing slashes in the `cms.root` variable and template path when constructing the metadata template URL during an API v3 Get call. It strips pre-existing leading and trailing slashes as appropriate before concatenating together a new URL with a new slash.

Testing Consideration: I have tested in our Bluebird CRM environment, which is currently CiviCRM 6.4.1, Drupal 7, PHP 8.3. I have also tested in CiviCRM 6.6.2, Backdrop CMS, PHP8.3. **I have NOT tested in Wordpress, which was the primary concern when an extra slash was previously added to the URL in [this commit](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/commit/77fa0ee8cb359603b8ba27c88c7bb3f533b4f306) .**

With that said, I encourage additional testing.