### PR TITLE
Replace deprecated CRM_Utils_Number::formatUnitSize

### DIFF
--- a/CRM/Mosaico/Page/Editor.php
+++ b/CRM/Mosaico/Page/Editor.php
@@ -145,7 +145,7 @@ class CRM_Mosaico_Page_Editor extends CRM_Core_Page {
    */
   protected function getMaxFileSize() {
     $fakeUnlimited = 25 * 1024 * 1024;
-    $iniVal = ini_get('upload_max_filesize') ? CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'), TRUE) : $fakeUnlimited;
+    $iniVal = ini_get('upload_max_filesize') ? ini_parse_quantity(ini_get('upload_max_filesize')) : $fakeUnlimited;
     $settingVal = Civi::settings()->get('maxFileSize') ? (1024 * 1024 * Civi::settings()->get('maxFileSize')) : $fakeUnlimited;
     return (int) min($iniVal, $settingVal);
   }


### PR DESCRIPTION
ini_parse_quantity is a built-in function since PHP 8.2 and is available in CiviCRM via polyfill since v5.53.

See https://github.com/civicrm/civicrm-core/pull/33755