### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Mosaico/AbDemux.php
+++ b/CRM/Mosaico/AbDemux.php
@@ -71,7 +71,7 @@ class CRM_Mosaico_AbDemux {
    * @param callable $continue
    *   The original/upstream implementation of Mailing.send_test API.
    * @return array
-   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
   public function onSendTestMailing($apiRequest, $continue) {
     if (empty($apiRequest['params']['mailing_id'])) {
@@ -114,12 +114,12 @@ class CRM_Mosaico_AbDemux {
    * @param callable $continue
    *   The original/upstream implementation of Mailing.submit API.
    * @return array
-   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
   public function onSubmitMailing($apiRequest, $continue) {
     civicrm_api3_verify_mandatory($apiRequest['params'], 'CRM_Mailing_DAO_Mailing', array('id'));
     if (!isset($apiRequest['params']['scheduled_date']) && !isset($apiRequest['params']['approval_date'])) {
-      throw new API_Exception("Missing parameter scheduled_date and/or approval_date");
+      throw new CRM_Core_Exception("Missing parameter scheduled_date and/or approval_date");
     }
 
     $api3 = $this->makeApi3($apiRequest);
@@ -230,7 +230,7 @@ class CRM_Mosaico_AbDemux {
    * @param array|object $mailing
    * @param array $variant
    * @return array|object
-   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function applyVariant(&$mailing, $variant) {
     $overrides = array_intersect(array_keys($variant), $this->variantFields);
@@ -253,7 +253,7 @@ class CRM_Mosaico_AbDemux {
       }
     }
     else {
-      throw new API_Exception("Cannot apply variant - unrecognized mailing object");
+      throw new CRM_Core_Exception("Cannot apply variant - unrecognized mailing object");
     }
     return $mailing;
   }

--- a/api/v3/MosaicoBaseTemplate.php
+++ b/api/v3/MosaicoBaseTemplate.php
@@ -42,7 +42,7 @@ function _civicrm_api3_mosaico_base_template_get_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mosaico_base_template_get($params) {
   return _civicrm_api3_basic_array_get('MosaicoBaseTemplate', $params, CRM_Mosaico_BAO_MosaicoTemplate::findBaseTemplates(), 'name',

--- a/api/v3/MosaicoTemplate.php
+++ b/api/v3/MosaicoTemplate.php
@@ -17,7 +17,7 @@ function _civicrm_api3_mosaico_template_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mosaico_template_create($params) {
   // Add current domain id to the template while creating
@@ -48,7 +48,7 @@ function civicrm_api3_mosaico_template_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mosaico_template_delete($params) {
   return _civicrm_api3_basic_delete('CRM_Mosaico_BAO_MosaicoTemplate', $params);
@@ -59,7 +59,7 @@ function civicrm_api3_mosaico_template_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mosaico_template_get($params) {
   // Added the current domain id to the template while retrieving
@@ -105,7 +105,7 @@ function _civicrm_api3_mosaico_template_clone_spec(&$spec) {
  * @param array $params
  *
  * @return array
- * @throws \CiviCRM_API3_Exception
+ * @throws \CRM_Core_Exception
  */
 function civicrm_api3_mosaico_template_clone($params) {
   $BLACKLIST = ['id'];
@@ -153,7 +153,7 @@ function _civicrm_api3_mosaico_template_replaceurls_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mosaico_template_replaceurls($params) {
   // If no `to_url` was passed, the current server base URL will be used


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.