### PR TITLE
Remove CSS override of core's mailing-preview dialog

### DIFF
--- a/css/mosaico-bootstrap.css
+++ b/css/mosaico-bootstrap.css
@@ -133,12 +133,6 @@
   margin-top: 30px;
 }
 
-div[ng-controller=PreviewMailingDialogCtrl] iframe.resized {
-  height: calc(100% - 57px);
-  position: absolute;
-  z-index: -1;
-}
-
 #bootstrap-theme .crm-mosaico-selected.center-block {
   float: none;
 }

--- a/sass/mosaico-bootstrap/_wizard.scss
+++ b/sass/mosaico-bootstrap/_wizard.scss
@@ -42,9 +42,3 @@
 .mosaico-templates-wrapper {
   margin-top: 30px;
 }
-
-div[ng-controller="PreviewMailingDialogCtrl"] iframe.resized {
-  height: calc(100% - 57px);
-  position: absolute;
-  z-index: -1;
-}


### PR DESCRIPTION
Open a mailing in the composer, click **Preview as HTML**, then toggle the dialog fullscreen or resize it. The preview disappears, and does not come back on further resizing — only on closing and reopening the dialog. This happens on any site with Mosaico installed, including when previewing a **non-Mosaico** mailing.

The cause is this rule, in `css/mosaico-bootstrap.css` and its SASS source:

```css
div[ng-controller=PreviewMailingDialogCtrl] iframe.resized {
  height: calc(100% - 57px);
  position: absolute;
  z-index: -1;
}
```

`PreviewMailingDialogCtrl` is a **CiviCRM core** controller, not one of Mosaico's, and `.resized` is added by core's own `crmUiIframe` directive on the first `dialogresize`. So the rule sits dormant until core resizes its preview dialog, and then applies to it: `position: absolute` takes the iframe out of flow, leaving the dialog's content box with nothing in it to give it height, and `z-index: -1` puts the iframe behind the dialog. Measured on open vs. after fullscreen, the iframe goes 255px → 0.

This PR deletes the rule from the built CSS and the SASS source both, so it does not return on the next build.

**Verified safe.** `PreviewMailingDialogCtrl` appears nowhere else in this extension and `.resized` is added only by core, so the selector's only possible target is core's dialog. To confirm nothing depended on it, I routed Mosaico's own Test-dialog preview back through core's `crmMailingPreviewMgr` with the rule deleted: it renders and survives both fullscreen and drag-resize, in Chrome and Firefox.

Tested on CiviCRM 6.16.2 with Mosaico 3.12.1773937815.

Same mailing, same action (toggle the dialog fullscreen):

<table><tr>
<td width="50%"><img width="100%" alt="With the rule present: the dialog titlebar is there but the content area is empty" src="https://github.com/user-attachments/assets/15c05be7-d8ff-4549-a56d-ec6bbc8e4c36" /></td>
<td width="50%"><img width="100%" alt="With the rule deleted: the preview renders and stays visible" src="https://github.com/user-attachments/assets/80c267f0-49cc-45ef-b398-b9c4f3695724" /></td>
</tr><tr>
<td align="center"><em>before: preview gone</em></td>
<td align="center"><em>after: preview renders</em></td>
</tr></table>

The preview is small in both, which is a separate core sizing issue described in #703 and not addressed here.

Fixes #703.
